### PR TITLE
Feature/sc 8359/add haspart metadata to json

### DIFF
--- a/build/cms_im-PR1142/activity-node-244425.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244425.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "name": "What Kind and How Many?",
     "courseCode": "6.2.1"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244425.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244425.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:eedef24f-7f96-5d4a-b3ad-91fbc1427542",
+  "identifier": "im:eedef24f-7f96-5d4a-b3ad-91fbc1427542",
+  "name": "What Kind and How Many?",
+  "alternateName": "6.2.1.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "courseCode": "6.2.1"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-1-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51831",
+  "dateCreated": "2019-05-20 07:45:05 UTC",
+  "dateModified": "2020-05-04 20:23:25 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">What Kind and How Many?</div>
+    <div class="im_statement"><p><img src="https://staging-cms-assets.illustrativemathematics.org/tPGnCWGv4B8KQN1RSXUrXDwd"/></p>
+
+<p>Think of different ways you could sort these figures. What categories could you use? How many groups would you have?<presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244426.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244426.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "name": "The Teacher&#x2019;s Collection",
     "courseCode": "6.2.1"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244426.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244426.ocx.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:93cbf6e6-11da-53df-bdfe-88a498c37c6f",
+  "identifier": "im:93cbf6e6-11da-53df-bdfe-88a498c37c6f",
+  "name": "The Teacher&#x2019;s Collection",
+  "alternateName": "6.2.1.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "courseCode": "6.2.1"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-1-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51832",
+  "dateCreated": "2019-05-20 07:45:06 UTC",
+  "dateModified": "2021-07-26 13:54:18 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">The Teacher&#x2019;s Collection</div>
+    <div class="im_statement"><ol>
+	<li>
+	<div>Think of a way to sort your teacher&#x2019;s collection into two or three categories. Count the items in each category, and record the information in the table.</div>
+
+	<table border="1">
+		<tbody>
+			<tr>
+				<th scope="col">category name</th>
+				<td scope="col" style="width:140px">&#xA0;</td>
+				<td scope="col" style="width:140px">&#xA0;</td>
+				<td scope="col" style="width:140px">&#xA0;</td>
+			</tr>
+			<tr>
+				<th scope="col">category&#xA0;amount</th>
+				<td>&#xA0;</td>
+				<td>&#xA0;</td>
+				<td>&#xA0;</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Pause here so your teacher can review your work.</p>
+	</li>
+	<li>
+	<p>Write at least two sentences that describe <strong>ratios</strong>&#xA0;in the collection. Remember, there are many ways to write a ratio:</p>
+
+	<ul>
+		<li>
+		<p>The ratio of <em>one category</em>&#xA0;to <em>another category</em>&#xA0;is ________ to ________.</p>
+		</li>
+		<li>
+		<p>The ratio of <em>one category</em>&#xA0;to <em>another category</em>&#xA0;is ________ : ________.</p>
+		</li>
+		<li>
+		<p>There are _______ of <em>one category</em>&#xA0;for every _______ of <em>another category</em>.<presentation-tag src="/presentation_tags/4.tag"/></p>
+		</li>
+	</ul>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244427.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244427.ocx.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:580a1985-11ef-5124-9948-90ed8e63b192",
+  "identifier": "im:580a1985-11ef-5124-9948-90ed8e63b192",
+  "name": "The Student&#x2019;s Collection",
+  "alternateName": "6.2.1.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "courseCode": "6.2.1"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-1-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51833",
+  "dateCreated": "2019-05-20 07:45:06 UTC",
+  "dateModified": "2021-07-26 13:55:16 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">The Student&#x2019;s Collection</div>
+    <div class="im_statement"><ol>
+	<li>
+	<p>Sort your collection into three categories. You can experiment with different ways of arranging these categories. Then, count the items in each category, and record the information in the table.</p>
+
+	<table border="1">
+		<tbody>
+			<tr>
+				<th scope="col">category name</th>
+				<td scope="col" style="width:140px">&#xA0;</td>
+				<td scope="col" style="width:140px">&#xA0;</td>
+				<td scope="col" style="width:140px">&#xA0;</td>
+			</tr>
+			<tr>
+				<th scope="col">category&#xA0;amount</th>
+				<td>&#xA0;</td>
+				<td>&#xA0;</td>
+				<td>&#xA0;</td>
+			</tr>
+		</tbody>
+	</table>
+	</li>
+	<li>
+	<p>Write at least two sentences that describe <strong>ratios</strong>&#xA0;in the collection. Remember, there are many ways to write a ratio:</p>
+
+	<ul>
+		<li>The ratio of <em>one category</em>&#xA0;to <em>another category</em>&#xA0;is ________ to ________.</li>
+		<li>The ratio of <em>one category</em>&#xA0;to <em>another category</em>&#xA0;is ________ : ________.</li>
+		<li>
+		<p>There are _______ of <em>one category</em>&#xA0;for every _______ of <em>another category</em>.</p>
+		</li>
+	</ul>
+
+	<p>Pause here so your teacher can review your sentences.</p>
+	</li>
+	<li>Make a visual display of your items that clearly shows one of your statements. Be prepared to share your display with the class.<presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"><div>
+<div>
+<div>
+<div>
+<ol>
+	<li>Use two colors to shade the rectangle so there are 2&#xA0;square units of one color for every 1&#xA0;square unit of the other color.</li>
+	<li>
+	<p>The rectangle you just colored has an area of 24 square units. Draw a different shape that does <em>not</em> have an area of 24 square units, but that can also be shaded with two colors in a <span><annotation description="\(2:1\)"/></span> ratio. Shade your new shape using two colors.</p>
+	<presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+</ol>
+</div>
+</div>
+
+<div>
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/QV8Xf5ofzpywnJDs67NzhgPJ"/></p>
+</div>
+</div>
+</div>
+</div>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244427.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244427.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "name": "The Student&#x2019;s Collection",
     "courseCode": "6.2.1"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244454.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244454.ocx.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:7149595b-794b-5336-9a09-4938d4c89ff4",
+  "identifier": "im:7149595b-794b-5336-9a09-4938d4c89ff4",
+  "name": "Number Talk: Dividing by 4 and Multiplying by $\\frac14$",
+  "alternateName": "6.2.2.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "courseCode": "6.2.2"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-2-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51835",
+  "dateCreated": "2019-05-20 07:45:07 UTC",
+  "dateModified": "2020-05-04 20:27:11 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Number Talk: Dividing by 4 and Multiplying by $\frac14$</div>
+    <div class="im_statement"><p>Find the value of each expression mentally.</p>
+
+<p><span><annotation description="\(24\div 4\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mfrac>
+    <mn>1</mn>
+    <mn>4</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>24</mn>
+</math><annotation description="\(\frac14\boldcdot 24\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>24</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mfrac>
+    <mn>1</mn>
+    <mn>4</mn>
+  </mfrac>
+</math><annotation description="\(24\boldcdot \frac14\)"/></span></p>
+
+<p><span><annotation description="\(5\div 4\)"/></span></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244454.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244454.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "name": "Number Talk: Dividing by 4 and Multiplying by $\\frac14$",
     "courseCode": "6.2.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244455.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244455.ocx.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:d0b60bd9-57ad-571c-8873-db70974555bd",
+  "identifier": "im:d0b60bd9-57ad-571c-8873-db70974555bd",
+  "name": "A Collection of Snap Cubes",
+  "alternateName": "6.2.2.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "courseCode": "6.2.2"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-2-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51836",
+  "dateCreated": "2019-05-20 07:45:07 UTC",
+  "dateModified": "2021-07-26 14:00:25 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">A Collection of Snap Cubes</div>
+    <div class="im_statement"><div>
+<div>
+<div>
+<p>Here is a collection of snap cubes.</p>
+</div>
+
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/vQ7GBdM18JmcJUh4p9GkF5JL"/></p>
+</div>
+</div>
+</div>
+
+<ol>
+	<li>Choose two of the colors in the image, and draw a diagram showing the number of snap cubes for these two colors.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>Trade papers with a partner. On their paper, write a sentence to describe a ratio shown in their diagram. Your partner will do the same for your diagram.</li>
+	<li>Return your partner&#x2019;s paper. Read the sentence written on your paper. If you disagree, explain your thinking.<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244455.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244455.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "name": "A Collection of Snap Cubes",
     "courseCode": "6.2.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244456.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244456.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "name": "Blue Paint and Art Paste",
     "courseCode": "6.2.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244456.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244456.ocx.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:29b412b2-774a-5983-ba51-77baa13303c4",
+  "identifier": "im:29b412b2-774a-5983-ba51-77baa13303c4",
+  "name": "Blue Paint and Art Paste",
+  "alternateName": "6.2.2.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "courseCode": "6.2.2"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-2-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51837",
+  "dateCreated": "2019-05-20 07:45:07 UTC",
+  "dateModified": "2021-07-26 13:57:41 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Blue Paint and Art Paste</div>
+    <div class="im_statement"><p>Elena mixed 2 cups of white paint with 6 tablespoons of blue paint.</p>
+
+<div>
+<div>
+<div>
+<p>Here is a diagram that represents this&#xA0;situation.</p>
+</div>
+
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/U6L65gXWqX3S7LK5nmdnE1s4"/></p>
+</div>
+</div>
+</div>
+
+<ol>
+	<li>
+	<p>Discuss each statement, and circle <strong>all</strong> those that correctly describe this situation. Make sure that both you and your partner agree with each circled answer.</p>
+
+	<ol>
+		<li>The ratio of cups of white paint to tablespoons of blue paint is <span><annotation description="\(2 : 6\)"/></span>.</li>
+		<li>For every cup of white paint, there are 2 tablespoons of blue paint.</li>
+		<li>There is 1 cup of white paint for every 3 tablespoons of blue paint.</li>
+		<li>There are 3 tablespoons of blue paint for every cup of white paint.</li>
+		<li>For each tablespoon of blue paint, there are 3 cups of white paint.</li>
+		<li>For every 6 tablespoons of blue paint, there are 2 cups of white paint.</li>
+		<li>The ratio of tablespoons of blue paint to cups of white paint is 6 to 2.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	</ol>
+	</li>
+	<li>
+	<p>Jada mixed 8 cups of flour with 2 pints of water to make paste for an art project.</p>
+
+	<ol>
+		<li>
+		<p>Draw a diagram that represents the situation.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/></p>
+		<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+		<li>Write at least two sentences describing the ratio of flour and water.<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+	</ol>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244457.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244457.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "name": "Card Sort: Spaghetti Sauce",
     "courseCode": "6.2.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244457.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244457.ocx.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:57f0754f-1302-537e-9041-8896aeafd7a5",
+  "identifier": "im:57f0754f-1302-537e-9041-8896aeafd7a5",
+  "name": "Card Sort: Spaghetti Sauce",
+  "alternateName": "6.2.2.4",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "courseCode": "6.2.2"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-2-4-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51838",
+  "dateCreated": "2019-05-20 07:45:08 UTC",
+  "dateModified": "2021-07-26 13:59:48 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Card Sort: Spaghetti Sauce</div>
+    <div class="im_statement"><div>
+<div>
+<div>
+<p>Your teacher will give you cards describing different recipes for spaghetti sauce. In the diagrams:</p>
+
+<ul>
+	<li>a circle represents a cup of tomato sauce</li>
+	<li>a square represents a tablespoon of oil</li>
+	<li>a triangle represents a teaspoon of oregano</li>
+</ul>
+</div>
+
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/QAdG7kPuksYxuVaaqqYjUA13"/></p>
+</div>
+</div>
+</div>
+
+<ol>
+	<li>
+	<p>Take turns with your partner to match a sentence with a diagram.</p>
+
+	<ol>
+		<li>For each match that you find, explain to your partner how you know it&#x2019;s a match.</li>
+		<li>For each match that your partner finds, listen carefully to their explanation. If you disagree, discuss your thinking and work to reach an agreement.</li>
+	</ol>
+	</li>
+	<li>After you and your partner have agreed&#xA0;on all of the matches, check your answers with the answer key. If there are any errors, discuss why and revise your matches.</li>
+	<li>
+	<p>There were two diagrams that each matched with two different sentences. Which were they?</p>
+
+	<ul>
+		<li>Diagram _______ matched with both sentences ______ and ______.</li>
+		<li>Diagram _______ matched with both sentences ______ and ______.</li>
+	</ul>
+	</li>
+	<li>Select one of the other diagrams and invent another sentence that could describe the ratio shown in the diagram.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"><p>Create a diagram that represents any of the ratios in a recipe of your choice. Is it possible to include more than 2 ingredients in your diagram?<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244478.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244478.ocx.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:4f69d547-f41d-5088-8a03-08f583ddec21",
+  "identifier": "im:4f69d547-f41d-5088-8a03-08f583ddec21",
+  "name": "Flower Pattern",
+  "alternateName": "6.2.3.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "courseCode": "6.2.3"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-3-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51840",
+  "dateCreated": "2019-05-20 07:45:08 UTC",
+  "dateModified": "2020-06-24 15:40:29 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Flower Pattern</div>
+    <div class="im_statement"><p>This flower is made up of yellow hexagons, red trapezoids, and green triangles.</p>
+
+<div>
+<div>
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/5bkUwdtYhzJpkRu2szUjikco"/></p>
+</div>
+
+<div>
+<ol>
+	<li>Write sentences to describe the ratios of the shapes that make up this pattern.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How many of each shape would be in two copies of this flower pattern?</li>
+</ol>
+</div>
+</div>
+</div>
+
+<p>&#xA0;<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244478.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244478.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "name": "Flower Pattern",
     "courseCode": "6.2.3"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244479.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244479.ocx.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:b931e3d8-ff69-5cea-a3d8-87885c3cee71",
+  "identifier": "im:b931e3d8-ff69-5cea-a3d8-87885c3cee71",
+  "name": "Powdered Drink Mix",
+  "alternateName": "6.2.3.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "courseCode": "6.2.3"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-3-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51841",
+  "dateCreated": "2019-05-20 07:45:08 UTC",
+  "dateModified": "2021-07-26 14:04:25 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Powdered Drink Mix</div>
+    <div class="im_statement"><p>Here are diagrams representing three mixtures of powdered drink mix and water:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/JbHRvR7Bfit4Grx1Q5JtHigx"/></p>
+
+<ol>
+	<li>
+	<p>How would the taste of Mixture A compare to the taste of Mixture B?</p>
+	<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>
+	<p>Use the diagrams to complete each statement:</p>
+
+	<ol>
+		<li>
+		<p>Mixture B uses ______ cups of water and ______ teaspoons of drink mix. The ratio of cups of water to teaspoons of drink mix in Mixture B is ________.</p>
+		</li>
+		<li>
+		<p>Mixture C uses ______ cups of water and ______ teaspoons of drink mix. The ratio of cups of water to teaspoons of drink mix in Mixture C is ________.</p>
+		</li>
+	</ol>
+	</li>
+	<li>How would the taste of Mixture B compare to the taste of Mixture C?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"><p>Sports drinks use sodium (better known as salt) to help people replenish electrolytes. Here are the nutrition labels of two sports drinks.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/KnUzqBoxPmqse4kW7TxmoYbY"/></p>
+
+<ol>
+	<li>Which of these drinks is saltier? Explain how you know.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>If you wanted to make sure a sports drink was less salty than both of the ones given, what ratio of sodium to water would you use?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244479.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244479.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "name": "Powdered Drink Mix",
     "courseCode": "6.2.3"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244480.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244480.ocx.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:5f9fede3-f9cc-5639-8166-6b8f92a930a4",
+  "identifier": "im:5f9fede3-f9cc-5639-8166-6b8f92a930a4",
+  "name": "Batches of Cookies",
+  "alternateName": "6.2.3.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "courseCode": "6.2.3"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-3-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51842",
+  "dateCreated": "2019-05-20 07:45:09 UTC",
+  "dateModified": "2020-06-24 15:40:29 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Batches of Cookies</div>
+    <div class="im_statement"><p>A recipe for one batch of cookies calls for 5 cups of flour and 2 teaspoons of vanilla.</p>
+
+<ol>
+	<li>
+	<p>Draw a diagram that shows the amount of flour and vanilla needed for <em>two</em> batches of cookies.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/></p>
+	<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How many batches can you make with 15 cups of flour and 6 teaspoons of vanilla? Show the additional batches by adding more ingredients to your diagram.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How much flour and vanilla would you need for 5 batches of cookies?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>
+	<p>Whether the ratio of cups of flour to teaspoons of vanilla is <span><annotation description="\(5:2\)"/></span>, <span><annotation description="\(10:4\)"/></span>, or <span><annotation description="\(15:6\)"/></span>, the recipes would make cookies that taste the same. We call these <strong>equivalent ratios</strong>.</p>
+
+	<ol>
+		<li>
+		<p>Find another ratio of cups of flour to teaspoons of vanilla that is equivalent to these ratios.</p>
+		<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+		<li>
+		<p>How many batches can you make using this new ratio of ingredients?</p>
+		<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+	</ol>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244480.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244480.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "name": "Batches of Cookies",
     "courseCode": "6.2.3"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244507.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244507.ocx.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:048b2bd1-a908-5899-b4b2-18e7de38252e",
+  "identifier": "im:048b2bd1-a908-5899-b4b2-18e7de38252e",
+  "name": "Number Talk: Adjusting a Factor",
+  "alternateName": "6.2.4.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "courseCode": "6.2.4"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-4-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51844",
+  "dateCreated": "2019-05-20 07:45:10 UTC",
+  "dateModified": "2020-05-04 20:23:27 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Number Talk: Adjusting a Factor</div>
+    <div class="im_statement"><p>Find the value of each product mentally.</p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>6</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>15</mn>
+</math><annotation description="\(6\boldcdot 15\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>12</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>15</mn>
+</math><annotation description="\(12\boldcdot 15\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>6</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>45</mn>
+</math><annotation description="\(6\boldcdot 45\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>13</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>45</mn>
+</math><annotation description="\(13\boldcdot 45\)"/></span></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244507.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244507.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "name": "Number Talk: Adjusting a Factor",
     "courseCode": "6.2.4"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244508.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244508.ocx.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:3f6af204-e08e-57ba-a41f-27ad047f92eb",
+  "identifier": "im:3f6af204-e08e-57ba-a41f-27ad047f92eb",
+  "name": "Turning Green",
+  "alternateName": "6.2.4.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "courseCode": "6.2.4"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-4-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51845",
+  "dateCreated": "2019-05-20 07:45:10 UTC",
+  "dateModified": "2021-07-26 14:07:34 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Turning Green</div>
+    <div class="im_statement"><p>Your teacher mixed milliliters of blue water and milliliters of yellow water in the ratio <span><annotation description="\(5:15\)"/></span>.</p>
+
+<ol>
+	<li>
+	<p>Doubling the original recipe:</p>
+
+	<ol>
+		<li>Draw a diagram to represent the amount of each color that you will combine to double your teacher&#x2019;s recipe.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+		<li>Use a marker to label an empty cup with the ratio of blue water to yellow water in this double batch.</li>
+		<li>Predict whether these amounts of blue and yellow will make the same shade of green as your teacher&#x2019;s mixture. Next, check your prediction by measuring those amounts and mixing them in the cup.</li>
+		<li>Is the ratio in your mixture equivalent to the ratio in your teacher&#x2019;s mixture? Explain your reasoning.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	</ol>
+	</li>
+	<li>
+	<p>Tripling the original recipe:</p>
+
+	<ol>
+		<li>Draw a diagram to represent triple your teacher&#x2019;s recipe.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+		<li>Label an empty cup with the ratio of blue water to yellow water.</li>
+		<li>Predict whether these amounts&#xA0;will make the same shade of green. Next, check your prediction by&#xA0;mixing those amounts.</li>
+		<li>Is the ratio in your new mixture equivalent to the ratio in your teacher&#x2019;s mixture? Explain your reasoning.<presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	</ol>
+	</li>
+	<li>
+	<p>Next, invent your own recipe for a <em>bluer</em> shade of green water.</p>
+
+	<ol>
+		<li>Draw a diagram to represent the amount of each color you will combine.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+		<li>Label the final empty cup with the ratio of blue water to yellow water in this recipe.</li>
+		<li>Test your recipe by mixing a batch in the cup. Does the mixture yield a bluer shade of green?</li>
+		<li>Is the ratio you used in this recipe equivalent to the ratio in your teacher&#x2019;s mixture? Explain your reasoning.<presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	</ol>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"><p>Someone has made a shade of green by using 17 ml&#xA0;of blue and 13 ml of yellow. They are sure it cannot be turned into the original shade of green by adding more blue or yellow. Either explain how more can be added to create the original green shade, or explain why this is impossible.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244508.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244508.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "name": "Turning Green",
     "courseCode": "6.2.4"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244509.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244509.ocx.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:ed6dddfb-800f-54ff-90de-4646efea9376",
+  "identifier": "im:ed6dddfb-800f-54ff-90de-4646efea9376",
+  "name": "Perfect Purple Water",
+  "alternateName": "6.2.4.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "courseCode": "6.2.4"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-4-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51846",
+  "dateCreated": "2019-05-20 07:45:10 UTC",
+  "dateModified": "2020-05-04 20:23:27 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Perfect Purple Water</div>
+    <div class="im_statement"><p>The recipe for Perfect Purple Water says, &#x201C;Mix 8 ml of blue water with 3 ml of red water.&#x201D;</p>
+
+<p>Jada mixes 24 ml of blue water with 9 ml of red water. Andre mixes 16 ml of blue water with 9 ml of red water.</p>
+
+<ol>
+	<li>Which person will get a color mixture that is the same shade as Perfect Purple Water? Explain or show your reasoning.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>
+	<p>Find another combination of blue water and red water that will also result in the same shade as Perfect Purple Water. Explain or show your reasoning.</p>
+	<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244509.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244509.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "name": "Perfect Purple Water",
     "courseCode": "6.2.4"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244535.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244535.ocx.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:0b4e7cb1-f917-571e-8a1e-f21ba5c61878",
+  "identifier": "im:0b4e7cb1-f917-571e-8a1e-f21ba5c61878",
+  "name": "Dots and Half Dots",
+  "alternateName": "6.2.5.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "courseCode": "6.2.5"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-5-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51848",
+  "dateCreated": "2019-05-20 07:45:10 UTC",
+  "dateModified": "2020-06-23 20:52:00 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Dots and Half Dots</div>
+    <div class="im_statement"><div>
+<div>
+<div>
+<p>Dot Pattern 1:<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/></p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/DrqtUFjxBkozUdtJfdmMDBNU"/></p>
+</div>
+
+<div>
+<p>Dot Pattern 2:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/f7jtCFr7hYGQBZdYamXWTuGB"/></p>
+</div>
+</div>
+</div>
+
+<p>&#xA0;<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244535.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244535.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "name": "Dots and Half Dots",
     "courseCode": "6.2.5"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244536.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244536.ocx.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:3e579587-b9e8-5f5f-9585-5136542627d0",
+  "identifier": "im:3e579587-b9e8-5f5f-9585-5136542627d0",
+  "name": "Tuna Casserole",
+  "alternateName": "6.2.5.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "courseCode": "6.2.5"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-5-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51849",
+  "dateCreated": "2019-05-20 07:45:11 UTC",
+  "dateModified": "2020-06-24 15:40:35 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Tuna Casserole</div>
+    <div class="im_statement"><p>Here is a recipe for tuna casserole.</p>
+
+<hr/>
+<div>
+<div>
+<div spellcheck="false">
+<p><strong>Ingredients</strong></p>
+
+<ul>
+	<li>3 cups cooked elbow-shaped pasta</li>
+	<li>6 ounce can tuna, drained</li>
+	<li>10 ounce can cream of chicken soup</li>
+	<li>1 cup shredded cheddar cheese</li>
+	<li>
+<span><annotation description="\(1 \frac12\)"/></span> cups French fried onions</li>
+</ul>
+</div>
+
+<div spellcheck="false">
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/fy4eihLxNLNChAN4Tp45a7Mv"/></p>
+</div>
+</div>
+</div>
+
+<p><strong>Instructions</strong><br/>
+Combine the pasta, tuna, soup, and half of the cheese. Transfer into a 9 inch by 18 inch baking dish. Put the remaining cheese on top. Bake 30 minutes at 350 degrees. During the last 5 minutes, add the French fried onions. Let sit for 10 minutes before serving.</p>
+
+<hr/>
+<ol>
+	<li>What is the ratio of the ounces of soup to the cups of shredded cheese to the cups of pasta in one batch of casserole?</li>
+	<li>How much of each of these 3 ingredients would be needed to make:
+	<ol>
+		<li>twice the amount of casserole?</li>
+		<li>half the amount of casserole?</li>
+		<li>five times the amount of casserole?</li>
+		<li>one-fifth the amount of casserole?</li>
+	</ol>
+	</li>
+	<li>What is the ratio of cups of pasta to ounces of tuna in one batch of casserole?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>
+	<p>How many batches of casserole would you make if you used the following amounts of ingredients?</p>
+
+	<ol>
+		<li>9 cups of pasta and 18 ounces of tuna?</li>
+		<li>36 ounces of tuna and 18 cups of pasta?</li>
+		<li>1 cup of pasta and 2 ounces of tuna?</li>
+	</ol>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"><p>The recipe says to use a 9 inch by 18 inch baking dish. Determine the length and width&#xA0;of a baking dish with the same height that could hold:</p>
+
+<ol>
+	<li>Twice the amount of casserole</li>
+	<li>Half the amount of casserole</li>
+	<li>Five times the amount of casserole</li>
+	<li>One-fifth the amount of casserole</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244536.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244536.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "name": "Tuna Casserole",
     "courseCode": "6.2.5"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244537.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244537.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "name": "What Are Equivalent Ratios?",
     "courseCode": "6.2.5"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244537.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244537.ocx.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:b131efa0-1022-55a9-ac94-57a447b93a3a",
+  "identifier": "im:b131efa0-1022-55a9-ac94-57a447b93a3a",
+  "name": "What Are Equivalent Ratios?",
+  "alternateName": "6.2.5.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "courseCode": "6.2.5"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-5-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51850",
+  "dateCreated": "2019-05-20 07:45:12 UTC",
+  "dateModified": "2021-07-26 14:09:47 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">What Are Equivalent Ratios?</div>
+    <div class="im_statement"><p>The ratios&#xA0;<span><annotation description="\(5:3\)"/></span> and <span><annotation description="\(10:6\)"/></span> are <strong>equivalent ratios</strong>.</p>
+
+<ol>
+	<li>Is the ratio <span><annotation description="\(15:12\)"/></span> equivalent to these? Explain your reasoning.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>Is the ratio <span><annotation description="\(30:18\)"/></span> equivalent to these? Explain your reasoning.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>Give two more examples of ratios that are equivalent to <span><annotation description="\(5:3\)"/></span>.</li>
+	<li>How do you know when ratios are equivalent and when they are <em>not</em> equivalent?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>
+	<p>Write a&#xA0;definition of <em>equivalent ratios</em>.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/></p>
+
+	<p>Pause here so your teacher can review your work and assign you a ratio to use for your visual display.</p>
+	</li>
+	<li>
+	<p>Create a visual display that includes:</p>
+
+	<ul>
+		<li>the title &#x201C;Equivalent Ratios&#x201D;</li>
+		<li>your best definition of <em>equivalent ratios</em>
+</li>
+		<li>the ratio your teacher assigned to you</li>
+		<li>at least two examples of ratios that are equivalent to your assigned ratio</li>
+		<li>an explanation of how you know these examples are equivalent</li>
+		<li>at least one example of a ratio that is <em>not</em> equivalent to your assigned ratio</li>
+		<li>an explanation of how you know this example is <em>not</em> equivalent</li>
+	</ul>
+
+	<p>Be prepared to share your display with the class.</p>
+	<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244562.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244562.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "name": "Number Talk: Adjusting Another Factor",
     "courseCode": "6.2.6"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244562.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244562.ocx.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:9590ad05-0fe2-5579-afd6-8f6f6959874c",
+  "identifier": "im:9590ad05-0fe2-5579-afd6-8f6f6959874c",
+  "name": "Number Talk: Adjusting Another Factor",
+  "alternateName": "6.2.6.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "courseCode": "6.2.6"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-6-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51852",
+  "dateCreated": "2019-05-20 07:45:12 UTC",
+  "dateModified": "2020-05-04 20:27:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Number Talk: Adjusting Another Factor</div>
+    <div class="im_statement"><p>Find the value of each product mentally.</p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mo stretchy="false">(</mo>
+  <mn>4.5</mn>
+  <mo stretchy="false">)</mo>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>4</mn>
+</math><annotation description="\((4.5)\boldcdot 4\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mo stretchy="false">(</mo>
+  <mn>4.5</mn>
+  <mo stretchy="false">)</mo>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>8</mn>
+</math><annotation description="\((4.5)\boldcdot 8\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mfrac>
+    <mn>1</mn>
+    <mn>10</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>65</mn>
+</math><annotation description="\(\frac{1} {10}\boldcdot 65\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mfrac>
+    <mn>2</mn>
+    <mn>10</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>65</mn>
+</math><annotation description="\(\frac{2} {10}\boldcdot 65\)"/></span><presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244563.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244563.ocx.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:52a029ea-c826-54ec-bec4-a0cb8eb8817d",
+  "identifier": "im:52a029ea-c826-54ec-bec4-a0cb8eb8817d",
+  "name": "Drink Mix on a Double Number Line",
+  "alternateName": "6.2.6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "courseCode": "6.2.6"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-6-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51853",
+  "dateCreated": "2019-05-20 07:45:12 UTC",
+  "dateModified": "2020-05-04 20:27:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Drink Mix on a Double Number Line</div>
+    <div class="im_statement"><p>The other day, we made drink mixtures&#xA0;by mixing 4 teaspoons of powdered drink mix for every cup of water. Here are two ways to represent multiple batches of this recipe:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/6KKTeh5tL6u3p7vnU5rjp4N5"/></p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/7gjEaJkTZjRjMToHakZxNkbQ"/></p>
+
+<ol>
+	<li>How can we tell that <span><annotation description="\(4:1\)"/></span> and <span><annotation description="\(12:3\)"/></span> are equivalent ratios?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How are these representations the same?&#xA0;How are these representations different?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How many teaspoons of drink mix should be used with 3 cups of water?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>How many cups of water should be used with 16 teaspoons of drink mix?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>What numbers should go in the empty boxes on the <strong>double number line diagram</strong>? What do these numbers mean?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"><p>Recall that a&#xA0;<em>perfect square</em> is a number of objects that can be arranged into a square. For example, 9 is a perfect square because 9 objects can be arranged into 3 rows of 3. 16 is also a perfect square, because 16 objects can be arranged into 4 rows of 4. In contrast, 12 is not a perfect square because you can&#x2019;t arrange 12 objects into a square.</p>
+
+<ol>
+	<li>How many whole numbers starting with 1 and ending with 100&#xA0;are perfect squares?&#xA0;<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>What about whole numbers starting with 1 and ending with 1,000?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244563.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244563.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "name": "Drink Mix on a Double Number Line",
     "courseCode": "6.2.6"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244564.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244564.ocx.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:b54acc83-b25a-56e8-9c21-d3b7a64d6fc8",
+  "identifier": "im:b54acc83-b25a-56e8-9c21-d3b7a64d6fc8",
+  "name": "Blue Paint on a Double Number Line",
+  "alternateName": "6.2.6.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "courseCode": "6.2.6"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-6-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51854",
+  "dateCreated": "2019-05-20 07:45:12 UTC",
+  "dateModified": "2020-05-04 20:27:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Blue Paint on a Double Number Line</div>
+    <div class="im_statement"><p>Here is a diagram showing Elena&#x2019;s recipe for light blue paint.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/U6L65gXWqX3S7LK5nmdnE1s4"/></p>
+
+<ol>
+	<li>
+	<p>Complete the double number line diagram to show the amounts of white paint and blue paint in different-sized batches of light blue paint.</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/hFicdzsGwvx5SWXV8CDdowYo"/></p>
+	</li>
+	<li>Compare your double number line diagram with your partner. Discuss your thinking. If needed, revise your diagram.</li>
+	<li>How many cups of white paint should Elena mix with 12 tablespoons of blue paint? How many batches would this make?</li>
+	<li>How many tablespoons of blue paint should Elena mix with 6 cups of white paint? How many batches would this make?</li>
+	<li>Use your double number line diagram to find another amount of white paint and blue paint that would make the same shade of light blue paint.</li>
+	<li>How do you know that these mixtures would make the same shade of light blue paint?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244564.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244564.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "name": "Blue Paint on a Double Number Line",
     "courseCode": "6.2.6"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244583.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244583.ocx.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:a22df16a-4942-519b-ac07-231cbc990a86",
+  "identifier": "im:a22df16a-4942-519b-ac07-231cbc990a86",
+  "name": "Ordering on a Number Line",
+  "alternateName": "6.2.7.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "courseCode": "6.2.7"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-7-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51856",
+  "dateCreated": "2019-05-20 07:45:13 UTC",
+  "dateModified": "2020-06-24 15:40:39 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Ordering on a Number Line</div>
+    <div class="im_statement"><ol>
+	<li>
+	<p>Locate and label the following numbers on the number line:</p>
+
+	<div>
+	<div>
+	<div>
+	<p><span><annotation description="\(\frac12\)"/></span></p>
+	</div>
+
+	<div>
+	<p><span><annotation description="\(\frac14\)"/></span></p>
+	</div>
+
+	<div>
+	<p><span><annotation description="\(1\frac34\)"/></span></p>
+	</div>
+
+	<div>
+	<p>1.5</p>
+	</div>
+
+	<div>
+	<p>1.75</p>
+	</div>
+	</div>
+	</div>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/P8X7aJAjnju3XhrofRK7eNqZ"/></p>
+	</li>
+	<li>Based on where you placed the numbers, locate and label four&#xA0;more fractions or decimals on the number line.</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244583.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244583.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "name": "Ordering on a Number Line",
     "courseCode": "6.2.7"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244584.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244584.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "name": "Just a Little Green",
     "courseCode": "6.2.7"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244584.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244584.ocx.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:0bd2e675-4eb5-56d8-8f63-e4035db81efc",
+  "identifier": "im:0bd2e675-4eb5-56d8-8f63-e4035db81efc",
+  "name": "Just a Little Green",
+  "alternateName": "6.2.7.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "courseCode": "6.2.7"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-7-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51857",
+  "dateCreated": "2019-05-20 07:45:13 UTC",
+  "dateModified": "2020-06-24 15:40:41 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Just a Little Green</div>
+    <div class="im_statement"><p>The other day, we made green water by mixing 5 ml of blue water with 15 ml of yellow water. We want to make a very small batch of the same shade of green water. We need to know how much yellow water to mix with only 1 ml of blue water.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/Me7Nx1qM1TYxJL3qH54UBZQN"/></p>
+
+<ol>
+	<li>On the number line for blue water, label the four tick marks shown.</li>
+	<li>On the number line for yellow water, draw and label tick marks to show the amount of yellow water needed for each amount of blue water.</li>
+	<li>How much yellow water should be used for 1 ml of blue water? Circle where you can see this on the double number line.</li>
+	<li>How much yellow water should be used for 11 ml of blue water?</li>
+	<li>How much yellow water should be used for 8 ml of blue water?</li>
+	<li>Why is it useful to know how much yellow water should be used with 1 ml of blue water?</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244585.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244585.ocx.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:9ef8c28c-8258-591f-838b-aec738a37f0b",
+  "identifier": "im:9ef8c28c-8258-591f-838b-aec738a37f0b",
+  "name": "Art Paste on a Double Number Line",
+  "alternateName": "6.2.7.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "courseCode": "6.2.7"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-7-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51858",
+  "dateCreated": "2019-05-20 07:45:13 UTC",
+  "dateModified": "2021-07-26 15:19:55 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Art Paste on a Double Number Line</div>
+    <div class="im_statement"><p>A recipe for art paste says&#xA0;&#x201C;For every 2 pints of water, mix in 8 cups of flour.&#x201D;</p>
+
+<ol>
+	<li>
+	<p>Follow the instructions to draw a double number line diagram representing the recipe for art paste.</p>
+
+	<ol>
+		<li>Use a ruler to draw two parallel lines.</li>
+		<li>Label the first line &#x201C;pints of water.&#x201D; Label the second line &#x201C;cups of flour.&#x201D;</li>
+		<li>Draw at least 6 equally spaced tick marks that line up on both lines.</li>
+		<li>Along the water line, label the tick marks with the amount of water in 0, 1, 2, 3, 4, and 5 batches of art paste.</li>
+		<li>Along the flour line, label the tick marks with the amount of flour in 0, 1, 2, 3, 4, and 5 batches of art paste.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	</ol>
+	</li>
+	<li>
+	<p>Compare your double number line diagram with your partner&#x2019;s. Discuss your thinking. If needed, revise your diagram.</p>
+	</li>
+	<li>
+	<p>Next, use your double number line to answer these questions:</p>
+
+	<ol>
+		<li>How much flour should be used with 10 pints of water?</li>
+		<li>How much water should be used with 24 cups of flour?</li>
+		<li>How much flour <strong>per&#xA0;</strong>pint of water does this recipe use?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	</ol>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"><p>A square with side of 10 units overlaps a square with side of 8 units in such a way that its corner <span><annotation description="\(B\)"/></span> is placed exactly at the center of the smaller square. As a result of the overlapping, the two sides of the large square intersect the two sides of the small square exactly at points <span><annotation description="\(C\)"/></span> and <span><annotation description="\(E\)"/></span>, as shown. The length of <span><annotation description="\(CD\)"/></span> is 6 units.</p>
+
+<div>
+<div>
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/eo3XGBEyLEvXkfqPNpfdG1kQ"/></p>
+</div>
+
+<div>
+<p>What is the area of the overlapping region <span><annotation description="\(CDEB\)"/></span>?</p>
+</div>
+</div>
+</div>
+
+<p>&#xA0;<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244585.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244585.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "name": "Art Paste on a Double Number Line",
     "courseCode": "6.2.7"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244586.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244586.ocx.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:42c9ba45-2821-5b32-90ef-5fbc3e7ced9f",
+  "identifier": "im:42c9ba45-2821-5b32-90ef-5fbc3e7ced9f",
+  "name": "Revisiting Tuna Casserole",
+  "alternateName": "6.2.7.4",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "courseCode": "6.2.7"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-7-4-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51859",
+  "dateCreated": "2019-05-20 07:45:13 UTC",
+  "dateModified": "2020-05-04 20:27:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Revisiting Tuna Casserole</div>
+    <div class="im_statement"><p>The other day, we looked at a recipe for tuna casserole that called for 10 ounces of cream of chicken soup for every 3 cups of elbow-shaped pasta.</p>
+
+<ol>
+	<li>Draw a double number line diagram that represents the amounts of soup and pasta in different-sized batches of this recipe.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>If you made a large amount of tuna casserole by mixing 40 ounces of soup with 15 cups of pasta, would it taste the same as the original recipe? Explain or show your reasoning.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>The original recipe called for 6 ounces of tuna for every 3 cups of pasta. Add a line to your diagram to represent the amount of tuna in different batches of casserole.</li>
+	<li>How many ounces of soup should you mix with 30 ounces of tuna to make a casserole that tastes the same as the original recipe?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244586.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244586.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "name": "Revisiting Tuna Casserole",
     "courseCode": "6.2.7"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244608.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244608.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:a2db9757-33ce-5535-b0a2-11461a63663d",
+  "identifier": "im:a2db9757-33ce-5535-b0a2-11461a63663d",
+  "name": "Number Talk: Remainders in Division",
+  "alternateName": "6.2.8.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "courseCode": "6.2.8"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-8-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51861",
+  "dateCreated": "2019-05-20 07:45:14 UTC",
+  "dateModified": "2020-06-24 15:40:44 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Number Talk: Remainders in Division</div>
+    <div class="im_statement"><p>Find the quotient mentally.</p>
+
+<p><span><annotation description="\(246\div 12\)"/></span></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244608.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244608.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "name": "Number Talk: Remainders in Division",
     "courseCode": "6.2.8"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244609.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244609.ocx.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:cbe89b6c-c306-54b4-900f-fd337d976536",
+  "identifier": "im:cbe89b6c-c306-54b4-900f-fd337d976536",
+  "name": "Grocery Shopping",
+  "alternateName": "6.2.8.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "courseCode": "6.2.8"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-8-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51862",
+  "dateCreated": "2019-05-20 07:45:14 UTC",
+  "dateModified": "2021-07-26 15:21:39 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Grocery Shopping</div>
+    <div class="im_statement"><p>Answer each question and explain or show your reasoning. If you get stuck, consider drawing a double number line diagram.</p>
+
+<ol>
+	<li>
+	<p>Eight avocados cost <span>$</span>4.</p>
+
+	<div>
+	<div>
+	<div>
+	<ol>
+		<li>How much do 16 avocados cost?</li>
+		<li>How much do 20 avocados cost?</li>
+		<li>How much do 9 avocados cost?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	</ol>
+	</div>
+
+	<div>
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/sxzm87qFG6zG1vgCHSVKAo3L"/></p>
+	</div>
+	</div>
+	</div>
+	</li>
+	<li>
+	<p>Twelve large bottles of water cost <span>$</span>9.</p>
+
+	<div>
+	<div>
+	<div>
+	<ol>
+		<li>How many bottles can you buy for <span>$</span>3?</li>
+		<li>What is the cost per bottle of water?</li>
+		<li>How much would 7&#xA0;bottles of water cost?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	</ol>
+	</div>
+
+	<div>
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/RV1onWnMnGZLXyyUThKSvQ2p"/></p>
+	</div>
+	</div>
+	</div>
+	</li>
+	<li>
+	<p>A 10-pound sack of flour costs <span>$</span>8.</p>
+
+	<ol>
+		<li>How much does 40 pounds of flour cost?</li>
+		<li>What is the cost per pound of flour?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+	</ol>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"><p>It is commonly thought that buying larger packages or containers, sometimes called <em>buying in bulk</em>, is a great way to save money. For example, a 6-pack of soda might cost <span>$</span>3 while a 12-pack of the same brand costs <span>$</span>5.</p>
+
+<p>Find 3 different cases where it is not true that buying in bulk saves money. You may use the internet or go to a local grocery store and take photographs of the cases you find. Make sure the products are the same brand. For each example that you find, give the quantity or size of each, and describe how you know that the larger size is not a better deal.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244609.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244609.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "name": "Grocery Shopping",
     "courseCode": "6.2.8"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244610.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244610.ocx.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:c29fe0e8-d33c-50a5-9e54-1065ece74c90",
+  "identifier": "im:c29fe0e8-d33c-50a5-9e54-1065ece74c90",
+  "name": "More Shopping",
+  "alternateName": "6.2.8.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "courseCode": "6.2.8"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-8-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51863",
+  "dateCreated": "2019-05-20 07:45:15 UTC",
+  "dateModified": "2021-07-26 15:22:24 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">More Shopping</div>
+    <div class="im_statement"><ol>
+	<li>
+	<p>Four bags of chips cost <span>$</span>6.</p>
+
+	<ol>
+		<li>What is the cost per bag?</li>
+		<li>At this rate, how much will 7 bags of chips cost?</li>
+	</ol>
+	</li>
+	<li>
+	<p>At a used book sale, 5 books cost <span>$</span>15.</p>
+
+	<ol>
+		<li>What is the cost per book?</li>
+		<li>At this rate, how many books can you buy for <span>$</span>21?</li>
+	</ol>
+	</li>
+	<li>
+	<div>
+	<div>
+	<div>
+	<p>Neon bracelets cost <span>$</span>1 for 4.</p>
+
+	<ol>
+		<li>What is the cost per bracelet?</li>
+		<li>At this rate, how much will 11 neon bracelets cost?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	</ol>
+
+	<p>Pause here so your teacher can review your work.</p>
+	</div>
+
+	<div>
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/mWwXMu4ijzoaPgLrg9ctpp3Q"/></p>
+	</div>
+	</div>
+	</div>
+	</li>
+	<li>Your teacher will assign you one of the problems. Create a visual display that shows your solution to the problem. Be prepared to share your solution with the class.<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244610.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244610.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "name": "More Shopping",
     "courseCode": "6.2.8"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244633.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244633.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "name": "Number Talk: Dividing by Powers of 10",
     "courseCode": "6.2.9"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244633.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244633.ocx.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:89e59cd7-8ac5-581f-9d28-cffbc6418de6",
+  "identifier": "im:89e59cd7-8ac5-581f-9d28-cffbc6418de6",
+  "name": "Number Talk: Dividing by Powers of 10",
+  "alternateName": "6.2.9.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "courseCode": "6.2.9"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-9-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51865",
+  "dateCreated": "2019-05-20 07:45:16 UTC",
+  "dateModified": "2020-05-04 20:27:14 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Number Talk: Dividing by Powers of 10</div>
+    <div class="im_statement"><p>Find the quotient mentally.</p>
+
+<p><span><annotation description="\(30\div 10\)"/></span></p>
+
+<p><span><annotation description="\(34\div 10\)"/></span></p>
+
+<p><span><annotation description="\(3.4\div 10\)"/></span></p>
+
+<p><span><annotation description="\(34\div 100\)"/></span></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244634.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244634.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "name": "Moving 10 Meters",
     "courseCode": "6.2.9"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244634.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244634.ocx.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:9cda7f06-db28-53ec-af1c-69a3fbbd3c2f",
+  "identifier": "im:9cda7f06-db28-53ec-af1c-69a3fbbd3c2f",
+  "name": "Moving 10 Meters",
+  "alternateName": "6.2.9.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "courseCode": "6.2.9"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-9-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51866",
+  "dateCreated": "2019-05-20 07:45:16 UTC",
+  "dateModified": "2021-07-26 15:27:31 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Moving 10 Meters</div>
+    <div class="im_statement"><p>Your teacher will set up a straight path with a 1-meter warm-up&#xA0;zone and a 10-meter measuring zone.&#xA0;Follow the following instructions to collect the data.</p>
+
+<p>&#x200B;<img src="https://staging-cms-assets.illustrativemathematics.org/V42aaQiqexFHyoJC5iQ1DiG2"/></p>
+
+<ol>
+	<li>
+	<ol>
+		<li>The person with the stopwatch (the &#x201C;timer&#x201D;) stands at the finish line. The person being timed (the &#x201C;mover&#x201D;) stands at the warm-up line.</li>
+		<li>On the first round, the mover starts moving <em>at a slow, steady speed</em> along the path. When the mover reaches the start line, they say, &#x201C;Start!&#x201D; and the timer starts the stopwatch.</li>
+		<li>The mover keeps moving steadily along the path. When they reach&#xA0;the finish line, the timer stops the stopwatch and records the time, rounded to the nearest second,&#xA0;in the table.</li>
+		<li>On the second round, the mover follows the same instructions, but this time, moving <em>at a quick, steady speed</em>. The timer records the time the same way.</li>
+		<li>Repeat these steps until each person in the group has gone twice:&#xA0;once at a slow, steady speed, and once at a quick, steady speed.
+		<table border="1">
+			<thead>
+				<tr>
+					<th scope="col">your slow moving time (seconds)</th>
+					<th scope="col">your fast moving time (seconds)</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td/>
+					<td/>
+				</tr>
+			</tbody>
+		</table>
+		</li>
+	</ol>
+	</li>
+	<li>
+	<p>After you finish collecting the data, use the double number line diagrams to answer the questions. Use the times your partner collected while you were moving.</p>
+
+	<p>Moving slowly:</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/6bpMnGfy1GYCQ7hpgzUKLrWm"/></p>
+
+	<p>Moving quickly:</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/6bpMnGfy1GYCQ7hpgzUKLrWm"/></p>
+
+	<ol>
+		<li>Estimate the distance in meters you traveled in 1 second when moving slowly.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+		<li>Estimate the distance in meters you traveled in 1 second when moving quickly.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+		<li>Trade diagrams with someone who is not your partner. How is the diagram representing someone moving slowly different from the diagram representing someone moving quickly?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	</ol>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244635.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244635.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "name": "Moving for 10 Seconds",
     "courseCode": "6.2.9"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244635.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244635.ocx.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:7dbed290-832e-5f41-aa7c-83c7b6dee93b",
+  "identifier": "im:7dbed290-832e-5f41-aa7c-83c7b6dee93b",
+  "name": "Moving for 10 Seconds",
+  "alternateName": "6.2.9.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "courseCode": "6.2.9"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-9-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51867",
+  "dateCreated": "2019-05-20 07:45:16 UTC",
+  "dateModified": "2020-06-24 15:40:51 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Moving for 10 Seconds</div>
+    <div class="im_statement"><p>Lin and Diego both ran for 10 seconds, each at their own constant speed. Lin ran 40 meters and Diego ran 55 meters.</p>
+
+<ol>
+	<li>Who was moving faster? Explain your reasoning.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>How far did each person move in 1 second? If you get stuck, consider drawing double number line diagrams to represent the situations.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>Use your data from the previous activity to find how far <em> you </em> could travel in 10 seconds at your quicker speed.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Han ran 100 meters in 20 seconds at a constant speed. Is this speed faster, slower, or the same as Lin&#x2019;s? Diego&#x2019;s? Yours?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"><p>Lin and Diego want to run a race in which they will both finish when the timer reads exactly 30 seconds. Who should get a head start, and how long should the head start be?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244661.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244661.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "name": "Treadmills",
     "courseCode": "6.2.10"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244661.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244661.ocx.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:a047f873-6a24-528a-af44-f4d08e8edf83",
+  "identifier": "im:a047f873-6a24-528a-af44-f4d08e8edf83",
+  "name": "Treadmills",
+  "alternateName": "6.2.10.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "courseCode": "6.2.10"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-10-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51869",
+  "dateCreated": "2019-05-20 07:45:17 UTC",
+  "dateModified": "2020-05-04 20:27:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Treadmills</div>
+    <div class="im_statement"><p>Mai and Jada each ran on a treadmill. The treadmill display&#xA0;shows&#xA0;the distance, in miles, each person ran&#xA0;and the amount of time it took them, in minutes and seconds.</p>
+
+<div>
+<div>
+<div>
+<p>Here is Mai&#x2019;s treadmill display:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/bj1EbRaZfLanz72uCfDiZSSV"/></p>
+</div>
+
+<div>
+<p>Here is Jada&#x2019;s treadmill display:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/4dyiXDh6FaVwCNmRLESSnBK4"/></p>
+</div>
+</div>
+</div>
+
+<ol>
+	<li>What is the same about their workouts? What is different about their workouts?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>If each person ran at a constant speed the entire time, who was running faster? Explain your reasoning.<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244662.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244662.ocx.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:2e31ffc9-c5e2-50d4-957a-b133c5bca97b",
+  "identifier": "im:2e31ffc9-c5e2-50d4-957a-b133c5bca97b",
+  "name": "Concert Tickets",
+  "alternateName": "6.2.10.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "courseCode": "6.2.10"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-10-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51870",
+  "dateCreated": "2019-05-20 07:45:18 UTC",
+  "dateModified": "2020-06-25 11:39:32 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Concert Tickets</div>
+    <div class="im_statement"><p>Diego paid <span>$</span>47&#xA0;for 3 tickets to a concert. Andre paid <span>$</span>141&#xA0;for 9 tickets to a concert. Did they pay at the <strong>same rate</strong>? Explain your reasoning.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244662.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244662.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "name": "Concert Tickets",
     "courseCode": "6.2.10"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244663.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244663.ocx.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:6456a693-daf9-55a2-874c-e27795b6ff3d",
+  "identifier": "im:6456a693-daf9-55a2-874c-e27795b6ff3d",
+  "name": "Sparkling Orange Juice",
+  "alternateName": "6.2.10.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "courseCode": "6.2.10"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-10-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51871",
+  "dateCreated": "2019-05-20 07:45:18 UTC",
+  "dateModified": "2020-06-24 15:40:50 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Sparkling Orange Juice</div>
+    <div class="im_statement"><p>Lin and Noah each have their own recipe for making&#xA0;sparkling orange juice.</p>
+
+<ul>
+	<li>Lin mixes 3 liters of orange juice with 4 liters of soda water.</li>
+	<li>Noah mixes&#xA0;4 liters of orange juice with 5 liters of soda water.</li>
+</ul>
+
+<p>How do the two mixtures compare in taste? Explain your reasoning.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/></p>
+</div>
+    <div class="im_extension"><ol>
+	<li>How can Lin make her sparkling orange juice taste the same as Noah&#x2019;s just by adding more of one ingredient? How much will she need?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How can Noah make his sparkling orange juice taste the same as Lin&#x2019;s just by adding more of one ingredient? How much will he need?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244663.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244663.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "name": "Sparkling Orange Juice",
     "courseCode": "6.2.10"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244687.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244687.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "name": "How Is It Growing?",
     "courseCode": "6.2.11"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244687.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244687.ocx.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:1d9d8498-c9b2-50bf-a563-d0d329e27da1",
+  "identifier": "im:1d9d8498-c9b2-50bf-a563-d0d329e27da1",
+  "name": "How Is It Growing?",
+  "alternateName": "6.2.11.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "courseCode": "6.2.11"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-11-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51873",
+  "dateCreated": "2019-05-20 07:45:19 UTC",
+  "dateModified": "2020-05-04 20:27:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">How Is It Growing?</div>
+    <div class="im_statement"><p>Look for a pattern in the figures.</p>
+
+<div>
+<div>
+<div>
+<ol>
+	<li>
+	<p>How many total tiles will be in:</p>
+
+	<ol>
+		<li>the 4th figure?</li>
+		<li>the&#xA0;5th figure?</li>
+		<li>the 10th figure?</li>
+	</ol>
+	</li>
+	<li>
+	<p>How do you see it growing?</p>
+	</li>
+</ol>
+</div>
+
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/rdZLvFPmkmYMhg2ry36wjCxP"/></p>
+</div>
+</div>
+</div>
+
+<p>&#xA0;<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244688.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244688.ocx.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:989e142a-1831-5cda-bbd3-a2c9fc0d8d67",
+  "identifier": "im:989e142a-1831-5cda-bbd3-a2c9fc0d8d67",
+  "name": "A Huge Amount of Sparkling Orange Juice",
+  "alternateName": "6.2.11.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "courseCode": "6.2.11"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-11-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51874",
+  "dateCreated": "2019-05-20 07:45:19 UTC",
+  "dateModified": "2020-06-24 15:40:52 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">A Huge Amount of Sparkling Orange Juice</div>
+    <div class="im_statement"><p>Noah&#x2019;s recipe for one batch of sparkling orange juice uses 4 liters of orange juice and 5 liters of soda water.</p>
+
+<ol>
+	<li>Use the double number line to show how many liters of each ingredient to use for different-sized batches of sparkling orange juice.
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/FMr1fDJ5B4JkidQyaARdGyrE"/></p>
+	</li>
+	<li>If someone mixes 36 liters of orange juice and 45 liters of soda water, how many batches would they make?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>If someone uses 400 liters of orange juice, how much soda water would they need?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>If someone uses 455 liters of soda water, how much orange juice would they need?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Explain the trouble with using a double number line diagram to answer the last two questions.<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244688.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244688.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "name": "A Huge Amount of Sparkling Orange Juice",
     "courseCode": "6.2.11"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244689.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244689.ocx.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:6d8e2e83-8abc-58b7-ac7d-c70f0d198933",
+  "identifier": "im:6d8e2e83-8abc-58b7-ac7d-c70f0d198933",
+  "name": "Batches of Trail Mix",
+  "alternateName": "6.2.11.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "courseCode": "6.2.11"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-11-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51875",
+  "dateCreated": "2019-05-20 07:45:20 UTC",
+  "dateModified": "2020-06-24 15:40:53 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Batches of Trail Mix</div>
+    <div class="im_statement"><p>A recipe for trail mix says: &#x201C;Mix 7 ounces of almonds with 5 ounces of raisins.&#x201D; Here is a <strong>table </strong>that has been started to show&#xA0;how many ounces of almonds and raisins would be in different-sized batches of this trail mix.</p>
+
+<div>
+<div>
+<div>
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">almonds (oz)</th>
+			<th scope="col">raisins (oz)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>7</td>
+			<td>5</td>
+		</tr>
+		<tr>
+			<td>28</td>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td>10</td>
+		</tr>
+		<tr>
+			<td>3.5</td>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td>250</td>
+		</tr>
+		<tr>
+			<td>56</td>
+			<td/>
+		</tr>
+	</tbody>
+</table>
+</div>
+
+<div>
+<ol>
+	<li>
+	<p>Complete the table so that ratios represented by each row are equivalent.</p>
+	</li>
+	<li>What methods did you use to fill in the table?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How do you know that each row shows a ratio that is equivalent<br/>
+	to <span><annotation description="\(7:5\)"/></span>? Explain your reasoning.</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+    <div class="im_extension"><p>You have created a best-selling recipe for chocolate chip cookies. The ratio of sugar to flour is <span><annotation description="\(2:5\)"/></span>.</p>
+
+<p>Create a table in which each entry represents amounts of sugar and flour that might be used at the same time in&#xA0;your recipe.</p>
+
+<ul>
+	<li>One entry should have amounts where you have fewer than 25 cups of flour.</li>
+	<li>One entry should have amounts where you have between 20&#x2013;30 cups of sugar.</li>
+	<li>One entry can have any amounts using more than 500 units of flour.<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ul>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244689.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244689.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "name": "Batches of Trail Mix",
     "courseCode": "6.2.11"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244710.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244710.ocx.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:49419b28-5297-5f1c-a83c-c106cbfa35b6",
+  "identifier": "im:49419b28-5297-5f1c-a83c-c106cbfa35b6",
+  "name": "Number Talk: Multiplying by a Unit Fraction",
+  "alternateName": "6.2.12.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "courseCode": "6.2.12"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-12-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51877",
+  "dateCreated": "2019-05-20 07:45:20 UTC",
+  "dateModified": "2020-05-04 20:27:16 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Number Talk: Multiplying by a Unit Fraction</div>
+    <div class="im_statement"><p>Find the product mentally.</p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mfrac>
+    <mn>1</mn>
+    <mn>3</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>21</mn>
+</math><annotation description="\(\frac13\boldcdot 21\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mfrac>
+    <mn>1</mn>
+    <mn>6</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>21</mn>
+</math><annotation description="\(\frac16 \boldcdot 21\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mo stretchy="false">(</mo>
+  <mn>5.6</mn>
+  <mo stretchy="false">)</mo>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mfrac>
+    <mn>1</mn>
+    <mn>8</mn>
+  </mfrac>
+</math><annotation description="\((5.6) \boldcdot \frac18\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mfrac>
+    <mn>1</mn>
+    <mn>4</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mo stretchy="false">(</mo>
+  <mn>5.6</mn>
+  <mo stretchy="false">)</mo>
+</math><annotation description="\(\frac14\boldcdot (5.6)\)"/></span></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244710.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244710.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "name": "Number Talk: Multiplying by a Unit Fraction",
     "courseCode": "6.2.12"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244711.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244711.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "name": "Comparing Taco Prices",
     "courseCode": "6.2.12"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244711.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244711.ocx.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:2990bc9d-7024-515e-8dda-40790f4cc5d3",
+  "identifier": "im:2990bc9d-7024-515e-8dda-40790f4cc5d3",
+  "name": "Comparing Taco Prices",
+  "alternateName": "6.2.12.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "courseCode": "6.2.12"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-12-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51878",
+  "dateCreated": "2019-05-20 07:45:20 UTC",
+  "dateModified": "2020-05-04 20:27:16 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Comparing Taco Prices</div>
+    <div class="im_statement"><div>
+<div>
+<div>
+<table border="1" style="width:200px">
+	<thead>
+		<tr>
+			<th scope="col">number&#xA0;of tacos</th>
+			<th scope="col">price&#xA0;in dollars</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td/>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td/>
+		</tr>
+	</tbody>
+</table>
+</div>
+
+<div>
+<p>Use the table to help you solve these problems. Explain or show your reasoning.</p>
+
+<ol>
+	<li>Noah bought 4 tacos and paid \$6. At this rate, how many tacos could he buy for \$15?</li>
+	<li>Jada&#x2019;s family bought 50 tacos for a party and paid \$72. Were Jada&#x2019;s tacos the same price as Noah&#x2019;s tacos?</li>
+</ol>
+</div>
+</div>
+</div>
+
+<p>&#xA0;<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244712.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244712.ocx.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:8abd27e9-ac06-5adc-a6ce-7b09aceb39e4",
+  "identifier": "im:8abd27e9-ac06-5adc-a6ce-7b09aceb39e4",
+  "name": "Hourly Wages",
+  "alternateName": "6.2.12.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "courseCode": "6.2.12"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-12-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51879",
+  "dateCreated": "2019-05-20 07:45:20 UTC",
+  "dateModified": "2020-06-25 11:39:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Hourly Wages</div>
+    <div class="im_statement"><p>Lin is paid \$90 for 5 hours of work. She used the table to calculate how much she would be paid at this rate for 8 hours of work.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/zTHN7Qv8dmA9gDLP3w9aWq45"/></p>
+
+<ol>
+	<li>What is the meaning of the 18 that appears in the table?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Why was the number <span><annotation description="\(\frac15\)"/></span> used as a multiplier?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Explain how Lin used this table to solve the problem.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>
+	<p>At this rate, how much would Lin be paid for 3 hours of work? For 2.1 hours of work?</p>
+	<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244712.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244712.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "name": "Hourly Wages",
     "courseCode": "6.2.12"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244713.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244713.ocx.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:d0509b9d-5dc2-54bd-affb-b315b40112d6",
+  "identifier": "im:d0509b9d-5dc2-54bd-affb-b315b40112d6",
+  "name": "Zeno&#x2019;s Memory Card",
+  "alternateName": "6.2.12.4",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "courseCode": "6.2.12"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-12-4-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51880",
+  "dateCreated": "2019-05-20 07:45:21 UTC",
+  "dateModified": "2020-06-24 15:41:00 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Zeno&#x2019;s Memory Card</div>
+    <div class="im_statement"><p>In 2016, 128 gigabytes (GB) of portable computer memory cost <span>$</span>32.</p>
+
+<ol>
+	<li>
+	<p>Here is a double number line that represents the situation:</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/F9bR6b4GguYU6YpexjJvVtNV"/></p>
+
+	<p>One set of tick marks has already been drawn to show the result of multiplying 128 and 32 each by <span><annotation description="\(\frac12\)"/></span>. Label the amount of memory and the cost for&#xA0;these tick marks.</p>
+
+	<p>Next, keep multiplying by <span><annotation description="\(\frac12\)"/></span> and drawing and labeling new tick marks, until you can no longer clearly label each new tick mark with a number.</p>
+	</li>
+	<li>
+	<p>Here is a table that represents the situation. Find the cost of 1 gigabyte. You can use as many rows as you need.</p>
+
+	<table border="1" style="width:240px">
+		<thead>
+			<tr>
+				<th scope="col">memory (gigabytes)</th>
+				<th scope="col">cost (dollars)</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>128</td>
+				<td>32</td>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+			</tr>
+		</tbody>
+	</table>
+	</li>
+	<li>Did you prefer the double number line or the table for solving this problem? Why?<presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"><p>A kilometer is 1,000 meters because <em>kilo</em> is a prefix that means 1,000. The prefix <em>mega</em> means 1,000,000 and <em>giga</em> (as in gigabyte) means 1,000,000,000. One byte is the amount of memory needed to store one letter of the alphabet. About how many of each of the following would fit on a 1-gigabyte flash drive?</p>
+
+<ol>
+	<li>letters</li>
+	<li>pages</li>
+	<li>books</li>
+	<li>movies</li>
+	<li>songs</li>
+</ol>
+
+<p>&#xA0;<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244713.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244713.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "name": "Zeno&#x2019;s Memory Card",
     "courseCode": "6.2.12"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244741.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244741.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "name": "Number Talk: Constant Dividend",
     "courseCode": "6.2.13"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244741.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244741.ocx.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:df3cb07e-1b84-596c-96a2-1b0c63ca812c",
+  "identifier": "im:df3cb07e-1b84-596c-96a2-1b0c63ca812c",
+  "name": "Number Talk: Constant Dividend",
+  "alternateName": "6.2.13.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "courseCode": "6.2.13"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-13-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51882",
+  "dateCreated": "2019-05-20 07:45:21 UTC",
+  "dateModified": "2020-05-04 20:23:33 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Number Talk: Constant Dividend</div>
+    <div class="im_statement"><p>Find the quotients mentally.</p>
+
+<p><span><annotation description="\(150\div 2\)"/></span></p>
+
+<p><span><annotation description="\(150\div 4\)"/></span></p>
+
+<p><span><annotation description="\(150\div 8\)"/></span></p>
+
+<p>Locate and label the quotients on the number line.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/75gUpRiGNhTeaR68EgV37D5S"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244742.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244742.ocx.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:f3e99fe4-4c1f-51f0-844c-cbd7df168f3c",
+  "identifier": "im:f3e99fe4-4c1f-51f0-844c-cbd7df168f3c",
+  "name": "Moving 3,000 Meters",
+  "alternateName": "6.2.13.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "courseCode": "6.2.13"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-13-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51883",
+  "dateCreated": "2019-05-20 07:45:21 UTC",
+  "dateModified": "2020-05-04 20:23:33 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Moving 3,000 Meters</div>
+    <div class="im_statement"><p>The other day, we saw that Han can run 100 meters in 20 seconds.</p>
+
+<p>Han wonders how long it would take him to run 3,000 meters at this rate. He made a table of equivalent ratios.</p>
+
+<ol>
+	<li>Do you agree that this table represents the situation? Explain your reasoning.
+	<table border="1" style="width:170px">
+		<tbody>
+			<tr>
+				<td>20</td>
+				<td>100</td>
+			</tr>
+			<tr>
+				<td>10</td>
+				<td>50</td>
+			</tr>
+			<tr>
+				<td>1</td>
+				<td>5</td>
+			</tr>
+			<tr>
+				<td>3,000</td>
+				<td>&#xA0;</td>
+			</tr>
+		</tbody>
+	</table>
+	</li>
+	<li>Complete the last row with the missing number.</li>
+	<li>What question about the situation does this number answer?<presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>What could Han do to improve his table?<presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>Priya can bike 150 meters in 20 seconds. At this rate, how long would it take her to bike 3,000 meters?
+	<table border="1" style="width:170px">
+		<tbody>
+			<tr>
+				<td>&#xA0; &#xA0; &#xA0; &#xA0;&#xA0;</td>
+				<td>&#xA0; &#xA0; &#xA0; &#xA0;&#xA0;</td>
+			</tr>
+			<tr>
+				<td>&#xA0;</td>
+				<td>&#xA0;</td>
+			</tr>
+			<tr>
+				<td>&#xA0;</td>
+				<td>&#xA0;</td>
+			</tr>
+			<tr>
+				<td>&#xA0;</td>
+				<td>&#xA0;</td>
+			</tr>
+			<tr>
+				<td>&#xA0;</td>
+				<td>&#xA0;</td>
+			</tr>
+			<tr>
+				<td>&#xA0;</td>
+				<td>&#xA0;</td>
+			</tr>
+		</tbody>
+	</table>
+	</li>
+	<li>
+	<p>Priya&#x2019;s neighbor has a dirt bike that can go 360 meters in 15 seconds. At this rate, how long would it take them to ride 3,000 meters?</p>
+	<presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244742.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244742.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "name": "Moving 3,000 Meters",
     "courseCode": "6.2.13"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244743.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244743.ocx.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:3aae636e-e597-5d55-9bd1-6c4883cd4f09",
+  "identifier": "im:3aae636e-e597-5d55-9bd1-6c4883cd4f09",
+  "name": "The International Space Station",
+  "alternateName": "6.2.13.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "courseCode": "6.2.13"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-13-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51884",
+  "dateCreated": "2019-05-20 07:45:21 UTC",
+  "dateModified": "2021-07-26 15:30:41 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">The International Space Station</div>
+    <div class="im_statement"><div>
+<div>
+<div>
+<p>The International Space Station orbits around the Earth at a constant speed. Your teacher will give you either a double number line or a table that represents this situation. Your partner will get the other representation.</p>
+</div>
+
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/3wr6VgFEyBX5x7KVxTS6NJrJ"/></p>
+</div>
+</div>
+</div>
+
+<ol>
+	<li>Complete the parts of your representation that you can figure out for sure.</li>
+	<li>Share information with your partner, and use the information that your partner shares to complete your representation.</li>
+	<li>What is the speed of the International Space Station?<presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>Place the two completed representations side by side. Discuss with your partner some ways in which they are the same and some ways in which they are different.</li>
+	<li>Record at least one way that they are the same and one way&#xA0;they are different.<presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"><p>Earth&#x2019;s circumference is about 40,000 kilometers and the orbit of the International Space Station is just a bit more than this. About how long does it take for the International Space Station to orbit Earth?<presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244743.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244743.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "name": "The International Space Station",
     "courseCode": "6.2.13"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244765.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244765.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "name": "What Do You Want to Know?",
     "courseCode": "6.2.14"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244765.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244765.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:0af6f728-bbd1-5525-ae39-a10f1e53c3ad",
+  "identifier": "im:0af6f728-bbd1-5525-ae39-a10f1e53c3ad",
+  "name": "What Do You Want to Know?",
+  "alternateName": "6.2.14.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "courseCode": "6.2.14"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-14-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51886",
+  "dateCreated": "2019-05-20 07:45:23 UTC",
+  "dateModified": "2020-06-23 20:52:29 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">What Do You Want to Know?</div>
+    <div class="im_statement"><p>Consider the&#xA0;problem: A red car and a blue car enter the highway at the same time and travel&#xA0;at a constant speed. How far apart are they after 4 hours?</p>
+
+<p>What information would you need to be able to solve&#xA0;the problem?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244766.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244766.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "name": "Info Gap: Hot Chocolate and Potatoes",
     "courseCode": "6.2.14"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244766.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244766.ocx.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:3366cf1d-3330-5652-92ae-f909526bfd86",
+  "identifier": "im:3366cf1d-3330-5652-92ae-f909526bfd86",
+  "name": "Info Gap: Hot Chocolate and Potatoes",
+  "alternateName": "6.2.14.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "courseCode": "6.2.14"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-14-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51887",
+  "dateCreated": "2019-05-20 07:45:23 UTC",
+  "dateModified": "2021-07-26 15:32:16 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Info Gap: Hot Chocolate and Potatoes</div>
+    <div class="im_statement"><p>Your teacher will give you either a <em>problem card</em> or a <em>data card</em>. Do not show or read your card to your partner.</p>
+
+<div>
+<div>
+<div>
+<p>If your teacher gives you the <em>problem card</em>:</p>
+
+<ol>
+	<li>
+	<p>Silently read your card and think about what information you need to be able to answer the question.</p>
+	</li>
+	<li>
+	<p>Ask your partner for the specific information that you need.</p>
+	</li>
+	<li>
+	<p>Explain how you are using the information to solve the problem.</p>
+
+	<p>Continue to ask questions until you have enough information to solve the problem.</p>
+	</li>
+	<li>
+	<p>Share the <em>problem card </em>and solve the problem independently.</p>
+	</li>
+	<li>
+	<p>Read the <em>data card</em>&#xA0;and discuss your reasoning.</p>
+	</li>
+</ol>
+</div>
+
+<div>
+<p>If your teacher gives you the <em>data card</em>:</p>
+
+<ol>
+	<li>
+	<p>Silently read your card.</p>
+	</li>
+	<li>
+	<p>Ask your partner <em>&#x201C;What specific information do you need?&#x201D;</em> and wait for them to <em>ask</em> for information.</p>
+
+	<p>If your partner asks for information that is not on the card, do not do the calculations for them. Tell them you don&#x2019;t have that information.</p>
+	</li>
+	<li>
+	<p>Before sharing the information, ask &#x201C;<em>Why do you need that information?</em>&#x201D; Listen to your partner&#x2019;s reasoning and ask clarifying questions.</p>
+	</li>
+	<li>
+	<p>Read the <em>problem card</em>&#xA0;and solve the problem independently.</p>
+	</li>
+	<li>
+	<p>Share the <em>data card</em>&#xA0;and discuss your reasoning.</p>
+	</li>
+</ol>
+</div>
+</div>
+</div>
+
+<p>Pause here so your teacher can review your work. Ask your teacher for a new set of cards and repeat the activity, trading roles with your partner.<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244767.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244767.ocx.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:26ac37ff-b61f-5af7-aa02-3ea0f096e913",
+  "identifier": "im:26ac37ff-b61f-5af7-aa02-3ea0f096e913",
+  "name": "Comparing Reading Rates",
+  "alternateName": "6.2.14.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "courseCode": "6.2.14"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-14-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51888",
+  "dateCreated": "2019-05-20 07:45:23 UTC",
+  "dateModified": "2020-05-04 20:27:17 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Comparing Reading Rates</div>
+    <div class="im_statement"><ul>
+	<li>Lin read the first 54 pages from a 270-page book in the last 3 days.</li>
+	<li>Diego read the first 100 pages from a 325-page book in the last 4 days.</li>
+	<li>Elena read the first 160 pages from a 480-page book in the last 5 days.</li>
+</ul>
+
+<p>If they continue to read every day at these rates, who will finish first, second, and third? Explain or show your reasoning.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/></p>
+</div>
+    <div class="im_extension"><p>The ratio of cats to dogs in a room is <span><annotation description="\(2:3\)"/></span>. Five&#xA0;more cats enter the room, and then the ratio of cats to dogs is <span><annotation description="\(9:11\)"/></span>. How many cats and dogs were in the room to begin with?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244767.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244767.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "name": "Comparing Reading Rates",
     "courseCode": "6.2.14"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244786.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244786.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "name": "True or False: Multiplying by a Unit Fraction",
     "courseCode": "6.2.15"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244786.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244786.ocx.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:44078494-5d7c-5b2a-ae72-f4a2b67b1f5a",
+  "identifier": "im:44078494-5d7c-5b2a-ae72-f4a2b67b1f5a",
+  "name": "True or False: Multiplying by a Unit Fraction",
+  "alternateName": "6.2.15.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "courseCode": "6.2.15"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-15-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51890",
+  "dateCreated": "2019-05-20 07:45:23 UTC",
+  "dateModified": "2020-06-23 20:52:31 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">True or False: Multiplying by a Unit Fraction</div>
+    <div class="im_statement"><p>True or false?</p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mfrac>
+    <mn>1</mn>
+    <mn>5</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>45</mn>
+  <mo>=</mo>
+  <mfrac>
+    <mn>45</mn>
+    <mn>5</mn>
+  </mfrac>
+</math><annotation description="\(\frac15 \boldcdot 45 = \frac{45}{5}\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mfrac>
+    <mn>1</mn>
+    <mn>5</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>20</mn>
+  <mo>=</mo>
+  <mfrac>
+    <mn>1</mn>
+    <mn>4</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>24</mn>
+</math><annotation description="\(\frac15 \boldcdot 20 = \frac14 \boldcdot 24\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>42</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mfrac>
+    <mn>1</mn>
+    <mn>6</mn>
+  </mfrac>
+  <mo>=</mo>
+  <mfrac>
+    <mn>1</mn>
+    <mn>6</mn>
+  </mfrac>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>42</mn>
+</math><annotation description="\(42 \boldcdot \frac16 = \frac16 \boldcdot 42\)"/></span></p>
+
+<p><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>486</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mfrac>
+    <mn>1</mn>
+    <mn>12</mn>
+  </mfrac>
+  <mo>=</mo>
+  <mfrac>
+    <mn>480</mn>
+    <mn>12</mn>
+  </mfrac>
+  <mo>+</mo>
+  <mfrac>
+    <mn>6</mn>
+    <mn>12</mn>
+  </mfrac>
+</math><annotation description="\(486 \boldcdot \frac{1}{12} = \frac{480}{12}+\frac{6}{12}\)"/></span></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244787.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244787.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "name": "Cubes of Paint",
     "courseCode": "6.2.15"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244787.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244787.ocx.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:7940898a-db1e-5a3e-b99e-9d0680e7c942",
+  "identifier": "im:7940898a-db1e-5a3e-b99e-9d0680e7c942",
+  "name": "Cubes of Paint",
+  "alternateName": "6.2.15.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "courseCode": "6.2.15"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-15-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51891",
+  "dateCreated": "2019-05-20 07:45:23 UTC",
+  "dateModified": "2022-12-09 17:32:28 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Cubes of Paint</div>
+    <div class="im_statement"><p>A recipe for maroon paint says, &#x201C;Mix 5 ml of red paint with 3 ml of blue paint.&#x201D;</p>
+
+<ol>
+	<li>Use snap cubes to represent the amounts of red and blue paint in the&#xA0;recipe. Then, draw a sketch of your snap-cube representation of the maroon paint.
+	<div>
+	<div>
+	<div>
+	<p/>
+	</div>
+
+	<div>
+	<ol>
+		<li>What amount does each cube represent?</li>
+		<li>How many milliliters of maroon paint will there be?</li>
+	</ol>
+	</div>
+	</div>
+	</div>
+	</li>
+	<li>
+	<ol>
+		<li>
+		<p>Suppose each cube represents 2 ml. How much of each color paint is there?</p>
+
+		<div>
+		<div>
+		<div>
+		<p>Red: _______ ml</p>
+		</div>
+
+		<div>
+		<p>Blue: _______ ml</p>
+		</div>
+
+		<div>
+		<p>Maroon: _______ ml</p>
+		</div>
+		</div>
+		</div>
+		</li>
+		<li>
+		<p>Suppose each cube represents 5 ml. How much of each color paint is there?</p>
+
+		<div>
+		<div>
+		<div>
+		<p>Red: _______ ml</p>
+		</div>
+
+		<div>
+		<p>Blue: _______ ml</p>
+		</div>
+
+		<div>
+		<p>Maroon: _______ ml</p>
+		</div>
+		</div>
+		</div>
+		</li>
+	</ol>
+	</li>
+	<li>
+	<ol>
+		<li>
+		<p>Suppose you need 80 ml of maroon paint. How much red and blue paint would you mix?&#xA0;Be prepared to explain your reasoning.</p>
+
+		<div>
+		<div>
+		<div>
+		<p>Red: _______ ml</p>
+		</div>
+
+		<div>
+		<p>Blue: _______ ml</p>
+		</div>
+
+		<div>
+		<p>Maroon: 80 ml</p>
+		</div>
+		</div>
+		</div>
+		<presentation-tag src="/presentation_tags/1.tag"/><presentation-tag src="/presentation_tags/1.tag"/>
+</li>
+		<li>If the original&#xA0;recipe is for one batch of maroon paint, how many batches are in 80 ml of maroon paint?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	</ol>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244788.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244788.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "name": "Sneakers, Chicken, and Fruit Juice",
     "courseCode": "6.2.15"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244788.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244788.ocx.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:575c8bf4-e11e-5fbd-9050-1be4ad8bff0f",
+  "identifier": "im:575c8bf4-e11e-5fbd-9050-1be4ad8bff0f",
+  "name": "Sneakers, Chicken, and Fruit Juice",
+  "alternateName": "6.2.15.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "courseCode": "6.2.15"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-15-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51892",
+  "dateCreated": "2019-05-20 07:45:24 UTC",
+  "dateModified": "2021-07-26 15:35:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Sneakers, Chicken, and Fruit Juice</div>
+    <div class="im_statement"><p>Solve each of the following problems and show your thinking. If you get stuck, consider drawing a <strong>tape diagram</strong> to represent the situation.</p>
+
+<ol>
+	<li>The ratio of students wearing sneakers to those wearing boots is 5 to 6. If there are 33 students in the class, and all of them are wearing either sneakers or boots, how many of them are wearing sneakers?<presentation-tag src="/presentation_tags/4.tag"/> <presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>A recipe for chicken marinade says, &#x201C;Mix 3 parts oil with 2 parts soy sauce and 1 part orange juice.&#x201D; If you need 42 cups of marinade in all, how much of each ingredient should you use?<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>Elena makes fruit punch by&#xA0;mixing&#xA0;4 parts cranberry juice to 3 parts apple juice to 2 parts grape juice. If one batch of fruit punch includes 30 cups of apple juice, how large is this batch of fruit punch?<presentation-tag src="/presentation_tags/4.tag"/> <presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"><p>Using the recipe from earlier, how much fruit punch can you make if you have 50 cups of cranberry juice, 40 cups of apple juice, and 30 cups of grape juice?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244789.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244789.ocx.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:096cb7b7-01ba-53af-8abf-f0d97f88d70b",
+  "identifier": "im:096cb7b7-01ba-53af-8abf-f0d97f88d70b",
+  "name": "Invent Your Own Ratio Problem",
+  "alternateName": "6.2.15.4",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "courseCode": "6.2.15"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-15-4-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51893",
+  "dateCreated": "2019-05-20 07:45:24 UTC",
+  "dateModified": "2021-07-26 15:36:06 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Invent Your Own Ratio Problem</div>
+    <div class="im_statement"><ol>
+	<li>Invent another ratio problem that can be solved with a tape diagram and solve it. If you get stuck, consider looking back at the problems you solved in the earlier activity.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>
+	<p>Create a visual display that includes:</p>
+
+	<ul>
+		<li>The new problem that you wrote, without the solution.</li>
+		<li>Enough work space for someone to show a solution.</li>
+	</ul>
+	</li>
+	<li>
+	<p>Trade your display with another group, and solve each other&#x2019;s problem. Include a tape diagram as part of your solution. Be prepared to share the solution with the class.</p>
+	</li>
+	<li>
+	<p>When the solution to the problem you invented is being shared by another group,&#xA0;check their answer for accuracy.</p>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244789.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244789.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "name": "Invent Your Own Ratio Problem",
     "courseCode": "6.2.15"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244810.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244810.ocx.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:ae5c628d-366b-5f8b-8143-00e94e504ab6",
+  "identifier": "im:ae5c628d-366b-5f8b-8143-00e94e504ab6",
+  "name": "You Tell the Story",
+  "alternateName": "6.2.16.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "courseCode": "6.2.16"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-16-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51895",
+  "dateCreated": "2019-05-20 07:45:24 UTC",
+  "dateModified": "2020-06-24 15:41:10 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">You Tell the Story</div>
+    <div class="im_statement"><p>Describe a situation with two quantities that this tape diagram could&#xA0;represent.</p>
+
+<div>
+<div>
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/kAAUFktF3hVWaRSYY2XwS6E8"/></p>
+</div>
+
+<div>
+<p/>
+</div>
+</div>
+</div>
+
+<p>&#xA0;<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244810.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244810.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "name": "You Tell the Story",
     "courseCode": "6.2.16"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244811.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244811.ocx.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:75d6f6d1-0c7b-5ba3-a197-d3fb787fed0c",
+  "identifier": "im:75d6f6d1-0c7b-5ba3-a197-d3fb787fed0c",
+  "name": "A Trip to the Aquarium",
+  "alternateName": "6.2.16.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "courseCode": "6.2.16"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-16-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51896",
+  "dateCreated": "2019-05-20 07:45:25 UTC",
+  "dateModified": "2020-06-24 15:41:07 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">A Trip to the Aquarium</div>
+    <div class="im_statement"><p>Consider the problem: A teacher is planning a class trip to the aquarium. The aquarium requires 2 chaperones for every 15 students. The teacher plans accordingly and orders a total of 85 tickets. How many tickets are for chaperones, and how many are for students?</p>
+
+<ol>
+	<li>
+	<p>Solve this problem in <em>one</em> of three ways:</p>
+
+	<div>
+	<div>
+	<div>
+	<p>Use a triple number line.</p>
+	</div>
+
+	<div>
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/JQfj8jRkAinHkF7Bxh9E3LWr"/></p>
+	</div>
+	</div>
+
+	<div>
+	<div>
+	<p>Use a table.<br/>
+	(Fill rows as needed.)&#xA0;</p>
+	</div>
+
+	<div>
+	<table border="1" style="width:250px">
+		<thead>
+			<tr>
+				<th scope="col">kids</th>
+				<th scope="col">chaperones</th>
+				<th scope="col">total</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>15</td>
+				<td>2</td>
+				<td>17</td>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+				<td/>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+				<td/>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+				<td/>
+			</tr>
+			<tr>
+				<td/>
+				<td/>
+				<td/>
+			</tr>
+		</tbody>
+	</table>
+	</div>
+	</div>
+	</div>
+
+	<p>Use a tape diagram.</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/oMyLJx8NFHoB1r62ykuBpvDW"/></p>
+	</li>
+	<li>After your class discusses all three strategies, which do you prefer for this problem and why?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"><p>Use the digits 1 through 9 to create three equivalent ratios. Use each digit only one time.</p>
+
+<p><span><annotation description="\(\boxed{\phantom{3}}:\boxed{\phantom{3}}\)"/></span> is equivalent to <span><annotation description="\(\boxed{\phantom{3}}\,\boxed{\phantom{3}}:\boxed{\phantom{3}}\)"/></span> and <span><annotation description="\(\boxed{\phantom{3}}\,\boxed{\phantom{3}}:\boxed{\phantom{3}}\,\boxed{\phantom{3}}\)"/></span><presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244811.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244811.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "name": "A Trip to the Aquarium",
     "courseCode": "6.2.16"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244812.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244812.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "name": "Salad Dressing and Moving Boxes",
     "courseCode": "6.2.16"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244812.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244812.ocx.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:1973ccaa-d922-5f73-a113-2ed43f91ec0a",
+  "identifier": "im:1973ccaa-d922-5f73-a113-2ed43f91ec0a",
+  "name": "Salad Dressing and Moving Boxes",
+  "alternateName": "6.2.16.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "courseCode": "6.2.16"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-16-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51897",
+  "dateCreated": "2019-05-20 07:45:25 UTC",
+  "dateModified": "2021-07-26 15:39:05 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Salad Dressing and Moving Boxes</div>
+    <div class="im_statement"><p>Solve each problem, and show your thinking. Organize it so it can be followed by others. If you get stuck, consider drawing a double number line,&#xA0;table, or&#xA0;tape diagram.</p>
+
+<ol>
+	<li>A recipe for salad dressing calls for 4 parts oil for every 3 parts vinegar. How much oil should you use to make a total of 28 teaspoons of dressing?<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>Andre and Han are moving boxes. Andre can move 4 boxes every half hour. Han can move 5 boxes every half hour. How long will it take Andre and Han to move all 72 boxes?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244834.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244834.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+    "name": "Fix It!",
     "courseCode": "6.2.17"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244834.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244834.ocx.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:3c930b8d-761b-5cc0-bb97-63bee8bd4939",
+  "identifier": "im:3c930b8d-761b-5cc0-bb97-63bee8bd4939",
+  "name": "Fix It!",
+  "alternateName": "6.2.17.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+    "courseCode": "6.2.17"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-17-1-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51899",
+  "dateCreated": "2019-05-20 07:45:26 UTC",
+  "dateModified": "2020-05-04 20:27:25 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Fix It!</div>
+    <div class="im_statement"><p>Andre likes a hot cocoa recipe with 1 cup of milk and 3 tablespoons of cocoa. He poured 1 cup of milk&#xA0;but accidentally added 5 tablespoons of cocoa.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/1Pa5XpNU2B5wVk293GetEUSV"/></p>
+
+<ol>
+	<li>How can you fix Andre&#x2019;s mistake and make his hot cocoa taste like the recipe?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>
+	<p>Explain how you know your adjustment will make Andre&#x2019;s hot cocoa taste the same as the one in the recipe.</p>
+	<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244835.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244835.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+    "name": "Who Was Fermi?",
     "courseCode": "6.2.17"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/activity-node-244835.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244835.ocx.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:18d72e97-6e56-5b5b-876d-e08579180af5",
+  "identifier": "im:18d72e97-6e56-5b5b-876d-e08579180af5",
+  "name": "Who Was Fermi?",
+  "alternateName": "6.2.17.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+    "courseCode": "6.2.17"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-17-2-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51900",
+  "dateCreated": "2019-05-20 07:45:26 UTC",
+  "dateModified": "2020-05-04 20:27:25 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Who Was Fermi?</div>
+    <div class="im_statement"><ol>
+	<li>Record the Fermi question that your class will explore together.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>Make an estimate of the answer. If making an estimate is too hard, consider writing down a number that would definitely be too low and another number that would definitely be too high.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>What are some smaller sub-questions we would need to figure out to reasonably answer our bigger question?<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>
+	<p>Think about how the smaller questions above should be organized to answer the big question. Label each smaller question with a number to show the order in which they should be answered. If you notice a gap in the set of sub-questions (i.e., there is an unlisted question that would need&#xA0;to be answered before the next one could be tackled), write another question to fill the gap.</p>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244836.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244836.ocx.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Activity",
+  "@id": "im:5c7de132-c80f-5855-a8b4-1960d23863c3",
+  "identifier": "im:5c7de132-c80f-5855-a8b4-1960d23863c3",
+  "name": "Researching Your Own Fermi Problem",
+  "alternateName": "6.2.17.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+    "courseCode": "6.2.17"
+  },
+  "learningResourceType": [
+    "Activity"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Activity",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-17-3-Activity-student-task-statements.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/activities/51901",
+  "dateCreated": "2019-05-20 07:45:26 UTC",
+  "dateModified": "2021-07-26 15:41:17 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Researching Your Own Fermi Problem</div>
+    <div class="im_statement"><ol>
+	<li>Brainstorm at least five Fermi problems that you want to research and solve. If you get stuck, consider starting with &#x201C;How much would it cost to . . .?&#x201D; or &#x201C;How long would it take to . . .?&#x201D;<presentation-tag src="/presentation_tags/6.tag"/><presentation-tag src="/presentation_tags/6.tag"/>
+</li>
+	<li>
+	<p>Pause here so your teacher can review your questions and approve one of them.</p>
+	<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+	<li>
+	<p>Use the graphic organizer to break your problem down into sub-questions.</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/nVczjtQaUcHxWdr11oaKSffv"/></p>
+	</li>
+	<li>
+	<p>Find the information you need to get closer to answering your question. Measure, make estimates, and perform any necessary calculations. If you get stuck, consider using tables or double number line diagrams.</p>
+	<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>
+	<p>Create a visual display that includes&#xA0;your Fermi problem and your solution. Organize your thinking&#xA0;so it can be followed by others.</p>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/activity-node-244836.ocx.html
+++ b/build/cms_im-PR1142/activity-node-244836.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+    "name": "Researching Your Own Fermi Problem",
     "courseCode": "6.2.17"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Activity"
   ],

--- a/build/cms_im-PR1142/assessment-node-244839.ocx.html
+++ b/build/cms_im-PR1142/assessment-node-244839.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "Check Your Readiness (A)",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment"
   ],

--- a/build/cms_im-PR1142/assessment-node-244839.ocx.html
+++ b/build/cms_im-PR1142/assessment-node-244839.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Assessment",
+  "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+  "identifier": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+  "name": "Check Your Readiness (A)",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Assessment",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-Check-Your-Readiness-(A)-assessment.docx"
+    },
+    {
+      "encodingFormat": "application/xml",
+      "contentUrl": "Grade6.2-Check-Your-Readiness-(A)-node-244839.qti.zip"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessments/2245",
+  "dateCreated": "2019-05-20 07:56:37 UTC",
+  "dateModified": "2020-05-04 20:23:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Check Your Readiness (A)</div>
+    <div class="Assessment.ocx:totalPoints">0</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-node-244846.ocx.html
+++ b/build/cms_im-PR1142/assessment-node-244846.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Assessment",
+  "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+  "identifier": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+  "name": "End-of-Unit Assessment (A)",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Assessment",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-End-of-Unit-Assessment-(A)-assessment.docx"
+    },
+    {
+      "encodingFormat": "application/xml",
+      "contentUrl": "Grade6.2-End-of-Unit-Assessment-(A)-node-244846.qti.zip"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessments/2247",
+  "dateCreated": "2019-05-20 07:56:37 UTC",
+  "dateModified": "2020-05-04 20:23:37 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">End-of-Unit Assessment (A)</div>
+    <div class="Assessment.ocx:totalPoints">0</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-node-244846.ocx.html
+++ b/build/cms_im-PR1142/assessment-node-244846.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "End-of-Unit Assessment (A)",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment"
   ],

--- a/build/cms_im-PR1142/assessment-node-266329.ocx.html
+++ b/build/cms_im-PR1142/assessment-node-266329.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Assessment",
+  "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+  "identifier": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+  "name": "Check Your Readiness (B)",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Assessment",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-Check-Your-Readiness-(B)-assessment.docx"
+    },
+    {
+      "encodingFormat": "application/xml",
+      "contentUrl": "Grade6.2-Check-Your-Readiness-(B)-node-266329.qti.zip"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessments/287",
+  "dateCreated": "2018-06-12 20:06:49 UTC",
+  "dateModified": "2020-05-04 20:23:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Check Your Readiness (B)</div>
+    <div class="Assessment.ocx:totalPoints">0</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-node-266329.ocx.html
+++ b/build/cms_im-PR1142/assessment-node-266329.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "Check Your Readiness (B)",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment"
   ],

--- a/build/cms_im-PR1142/assessment-node-266337.ocx.html
+++ b/build/cms_im-PR1142/assessment-node-266337.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "End-of-Unit Assessment (B)",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment"
   ],

--- a/build/cms_im-PR1142/assessment-node-266337.ocx.html
+++ b/build/cms_im-PR1142/assessment-node-266337.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Assessment",
+  "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+  "identifier": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+  "name": "End-of-Unit Assessment (B)",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Assessment",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-End-of-Unit-Assessment-(B)-assessment.docx"
+    },
+    {
+      "encodingFormat": "application/xml",
+      "contentUrl": "Grade6.2-End-of-Unit-Assessment-(B)-node-266337.qti.zip"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessments/318",
+  "dateCreated": "2018-06-13 17:32:41 UTC",
+  "dateModified": "2020-05-05 13:50:04 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">End-of-Unit Assessment (B)</div>
+    <div class="Assessment.ocx:totalPoints">0</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244840.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244840.ocx.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:11cadb5b-0beb-5d17-8e36-315aeb94d3ab",
+  "identifier": "im:11cadb5b-0beb-5d17-8e36-315aeb94d3ab",
+  "name": "Consider these fractions: $\\frac23$, $\\frac45$, $\\frac69$. Two of these. . .",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14832",
+  "dateCreated": "2019-05-20 07:56:40 UTC",
+  "dateModified": "2020-06-24 16:49:08 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p>Here are three fractions: <span><annotation description="\(\frac23\)"/></span>, <span><annotation description="\(\frac45\)"/></span>, <span><annotation description="\(\frac69\)"/></span>. Two of these fractions are equivalent to each other. Which two? Explain or show your reasoning.<presentation-tag src="/presentation_tags/5.tag"/></p>
+</div>
+    <div class="AssessmentProblem.solution"><p><span><annotation description="\(\frac23\)"/></span> and <span><annotation description="\(\frac69\)"/></span> are equivalent to each other. Possible strategies:</p>
+
+<ul>
+	<li>2 and 3 can be multiplied by 3 to get 6 and 9.</li>
+	<li>Here is a diagram:
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/RdSexAJewWpvp4jUTbaYdzeN"/></p>
+	</li>
+</ul>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244840.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244840.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "name": "Consider these fractions: $\\frac23$, $\\frac45$, $\\frac69$. Two of these. . .",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244841.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244841.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "name": "1. 28 is 7 times what number?   2. 8 is 32 times what number?   3. 4000. . .",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244841.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244841.ocx.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:3c42ed66-cbef-590f-a47c-b132bf0b65c9",
+  "identifier": "im:3c42ed66-cbef-590f-a47c-b132bf0b65c9",
+  "name": "1. 28 is 7 times what number?   2. 8 is 32 times what number?   3. 4000. . .",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14833",
+  "dateCreated": "2019-05-20 07:56:40 UTC",
+  "dateModified": "2020-06-24 16:49:08 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><ol>
+	<li>28 is 7 times what number?</li>
+	<li>8 is 32 times what number?</li>
+	<li>4000 is 4 times what number?</li>
+	<li>Choose one part and explain how you know your answer is correct.<presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><ol>
+	<li>4</li>
+	<li><span><annotation description="\(\frac14\)"/></span></li>
+	<li>1000</li>
+	<li>Explanations vary.</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244842.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244842.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "name": "Write the missing number under each tick mark on the number line. . .",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244842.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244842.ocx.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:113d3eb8-a939-5e41-9d57-6accf08c769e",
+  "identifier": "im:113d3eb8-a939-5e41-9d57-6accf08c769e",
+  "name": "Write the missing number under each tick mark on the number line. . .",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14834",
+  "dateCreated": "2019-05-20 07:56:40 UTC",
+  "dateModified": "2020-05-04 20:23:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">ShortAnswerResponse</div>
+    <div class="AssessmentProblem.statement"><p>Label&#xA0;each tick mark with its location&#xA0;on the number line:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/WJk99kDvXDX9shzyMn2c9eUX"/></p>
+
+<p>&#xA0;<presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="AssessmentProblem.solution"><p><img src="https://staging-cms-assets.illustrativemathematics.org/6ysKFSaFVhxBKnm8QeCpDgcV"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244843.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244843.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "name": "//6.2.DPA_Image_4 alt: &#x201C;&#x201D;      1. Write a fraction for point A.  2. Now. . .",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244843.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244843.ocx.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:0d6726f0-0e06-5437-a563-19fb85368da9",
+  "identifier": "im:0d6726f0-0e06-5437-a563-19fb85368da9",
+  "name": "//6.2.DPA_Image_4 alt: &#x201C;&#x201D;      1. Write a fraction for point A.  2. Now. . .",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14835",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2020-06-24 16:49:08 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">ShortAnswerResponse</div>
+    <div class="AssessmentProblem.statement"><p>Here is a number line:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/X1xaFSQAo6jdeU4Rnv63degf"/></p>
+
+<ol>
+	<li>Write the number at <span><annotation description="\(A\)"/></span> as a fraction.<presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Write the number at <span><annotation description="\(A\)"/></span> as an equivalent fraction.<presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><ol>
+	<li>
+<span><annotation description="\(\frac14\)"/></span> (or equivalent)</li>
+	<li>
+<span><annotation description="\(\frac28\)"/></span> (or equivalent, but different from previous answer)</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244844.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244844.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "name": "One batch of brownies calls for 1 box of brownie mix and the ingredients. . .",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244844.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244844.ocx.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:460777f7-5510-5039-8777-e3f92e73eb43",
+  "identifier": "im:460777f7-5510-5039-8777-e3f92e73eb43",
+  "name": "One batch of brownies calls for 1 box of brownie mix and the ingredients. . .",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14836",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2020-06-24 16:49:09 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">ShortAnswerResponse</div>
+    <div class="AssessmentProblem.statement"><p>One batch of brownies calls for 1 box of brownie mix and the ingredients shown.</p>
+
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="row">type of brownie</th>
+			<th scope="col">eggs</th>
+			<th scope="col">water</th>
+			<th scope="col">oil</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>fudge-like</td>
+			<td>2 eggs</td>
+			<td>
+<span><annotation description="\(\frac14\)"/></span> cup</td>
+			<td>
+<span><annotation description="\(\frac12\)"/></span> cup</td>
+		</tr>
+		<tr>
+			<td>cake-like</td>
+			<td>3 eggs</td>
+			<td>
+<span><annotation description="\(\frac14\)"/></span> cup</td>
+			<td>
+<span><annotation description="\(\frac12\)"/></span> cup</td>
+		</tr>
+	</tbody>
+</table>
+
+<ol>
+	<li>What amounts of eggs, water, and oil would you need for 2 batches of fudge-like brownies?<presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>What amounts of eggs, water, and oil would you need for 3 batches of cake-like brownies?<presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><ol>
+	<li>4 eggs, <span><annotation description="\(\frac12\)"/></span>&#xA0;cup water, 1 cup oil (or equivalent)</li>
+	<li>9 eggs, <span><annotation description="\(\frac34\)"/></span>&#xA0;cup water, <span><annotation description="\(1\frac12\)"/></span>&#xA0;cups oil&#xA0;(or equivalent)</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244845.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244845.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "name": "What travels faster: a car that travels 6 miles in 10 minutes at a. . .",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244845.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244845.ocx.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:5ebd36b8-2eab-58bd-869e-cc40bd1c3feb",
+  "identifier": "im:5ebd36b8-2eab-58bd-869e-cc40bd1c3feb",
+  "name": "What travels faster: a car that travels 6 miles in 10 minutes at a. . .",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14837",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2020-05-04 20:23:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p>Which travels faster: a car that travels 6 miles in 10 minutes at a constant speed, or a train that travels 6 miles in 8 minutes at a constant speed? Explain how you know.<presentation-tag src="/presentation_tags/4.tag"/></p>
+</div>
+    <div class="AssessmentProblem.solution"><p>The train travels faster because it covers the same distance as the car in less time.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244847.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244847.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:e706eb4f-e87c-5199-9811-0bd1b6c8c145",
+  "identifier": "im:e706eb4f-e87c-5199-9811-0bd1b6c8c145",
+  "name": "Select all the true statements. The ratio of triangles...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14838",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2020-06-24 16:49:11 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">MultipleSelectResponse</div>
+    <div class="AssessmentProblem.statement"><p>Select <strong>all</strong> the true statements.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/YHfrSJMEbF5My9awNVd1Byp4"/></p>
+</div>
+    <div class="AssessmentProblem.solution">["A", "D", "F"]</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244847.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244847.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "name": "Select all the true statements. The ratio of triangles...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244848.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244848.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "name": "Which of the following ratios are equivalent to $8:6$ ? Select all that...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244848.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244848.ocx.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:105b3181-b7b0-5e06-887e-57135c9906d4",
+  "identifier": "im:105b3181-b7b0-5e06-887e-57135c9906d4",
+  "name": "Which of the following ratios are equivalent to $8:6$ ? Select all that...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14839",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2020-06-24 16:49:10 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">MultipleSelectResponse</div>
+    <div class="AssessmentProblem.statement"><p>Select <strong>all</strong> the ratios that are equivalent to <span><annotation description="\(8:6\)"/></span></p>
+</div>
+    <div class="AssessmentProblem.solution">["A", "C"]</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244849.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244849.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "name": "A mixture of purple paint contains 6 teaspoons of red paint and 15...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244849.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244849.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:0e2d967c-60f5-5d3c-ad8f-a81b462734ed",
+  "identifier": "im:0e2d967c-60f5-5d3c-ad8f-a81b462734ed",
+  "name": "A mixture of purple paint contains 6 teaspoons of red paint and 15...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14840",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2020-05-04 20:27:25 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">MultipleChoiceResponse</div>
+    <div class="AssessmentProblem.statement"><p>A mixture of purple paint contains 6 teaspoons of red paint and 15 teaspoons of blue paint. To make the same shade of purple paint using 35 teaspoons of blue paint, how much red paint would you need? Use the double number line diagram to help if needed.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/r6YMzYKscoKSB4LqTbBA52Xz"/></p>
+</div>
+    <div class="AssessmentProblem.solution">1</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244850.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244850.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "name": "Lin rode her bike 2 miles in 8 minutes. She rode at a constant speed....",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244850.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244850.ocx.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:0888b079-a5e5-59c3-8e8a-83b9f621c818",
+  "identifier": "im:0888b079-a5e5-59c3-8e8a-83b9f621c818",
+  "name": "Lin rode her bike 2 miles in 8 minutes. She rode at a constant speed....",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14841",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2020-05-04 20:27:25 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">ShortAnswerResponse</div>
+    <div class="AssessmentProblem.statement"><p>Lin rode her bike 2 miles in 8 minutes. She rode at a constant speed. Complete the table to show the time it took her to travel different distances at this speed.</p>
+
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">distance traveled (miles)</th>
+			<th scope="col">elapsed time (minutes)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>2</td>
+			<td>8</td>
+		</tr>
+		<tr>
+			<td>1</td>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td>1</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>&#xA0;<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="AssessmentProblem.solution"><table border="1">
+	<thead>
+		<tr>
+			<th scope="col">distance traveled (miles)</th>
+			<th scope="col">elapsed time (minutes)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>2</td>
+			<td>8</td>
+		</tr>
+		<tr>
+			<td>1</td>
+			<td>4</td>
+		</tr>
+		<tr>
+			<td><span><annotation description="\(\frac14\)"/></span></td>
+			<td>1</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244851.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244851.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "name": "Solve each of the following:      1. 3 movie tickets cost \\$36. At this...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244851.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244851.ocx.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:0c49c259-b783-593c-adf7-27c619133707",
+  "identifier": "im:0c49c259-b783-593c-adf7-27c619133707",
+  "name": "Solve each of the following:      1. 3 movie tickets cost \\$36. At this...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14842",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2020-06-25 11:57:56 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">ShortAnswerResponse</div>
+    <div class="AssessmentProblem.statement"><p>Solve each of the following:</p>
+
+<ol>
+	<li>3 movie tickets cost <span>$</span>36. At this rate, what is the cost per ticket?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>3 ice cream cones cost <span>$</span>8.25. At this rate, how much do 2 ice cream cones cost?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>3 bananas cost <span>$</span>0.99. At this rate, how much do 5 bananas cost?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><ol>
+	<li>
+<span>$</span>12</li>
+	<li>
+<span>$</span>5.50</li>
+	<li>
+<span>$</span>1.65</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244852.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244852.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "name": "A bag contains 120 marbles. Some are red and the rest are black. There...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-244852.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244852.ocx.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:d1e2d9e0-f630-5b35-9600-e728c30a08b0",
+  "identifier": "im:d1e2d9e0-f630-5b35-9600-e728c30a08b0",
+  "name": "A bag contains 120 marbles. Some are red and the rest are black. There...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14843",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2020-05-04 20:27:26 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p>A bag contains 120 marbles. Some are red and the rest are black. There are 19 red marbles for every black marble. How many red marbles are in the bag? Explain your reasoning.<presentation-tag src="/presentation_tags/2.tag"/></p>
+</div>
+    <div class="AssessmentProblem.solution"><p>114 red marbles. Explanations vary. Sample explanation: Make a table in which the first row has 19 red marbles and 1 black marble. We want to find the row where the total number of marbles is 120. Multiplying the first row by 6 gives&#xA0;114 red marbles and 6 black marbles, which add to&#xA0;the correct total.</p>
+
+<p>Minimal Tier 1 response:</p>
+
+<ul>
+	<li>Work is complete and correct.</li>
+	<li>Sample: <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>19</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>6</mn>
+  <mo>=</mo>
+  <mn>114</mn>
+</math><annotation description="\(19 \boldcdot 6 = 114\)"/></span>, so there are 114 red marbles and 6 black marbles.</li>
+</ul>
+
+<p>Tier 2 response:</p>
+
+<ul>
+	<li>Work shows general conceptual understanding and mastery, with some errors.</li>
+	<li>Sample errors: Red and black marbles are in the correct ratio but do not total 120; correct answer with no&#xA0;work shown and no explanation; work involves&#xA0;some correct reasoning about equivalent ratios with some errors.</li>
+</ul>
+
+<p>Tier 3 response:</p>
+
+<ul>
+	<li>Significant errors in work demonstrate lack of conceptual understanding or mastery.</li>
+	<li>Sample errors: Work does not show evidence of an understanding of equivalent ratios; incorrect answer with no work shown.</li>
+</ul>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244853.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244853.ocx.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:b7315211-05d1-5889-b07c-4dd15e8c83eb",
+  "identifier": "im:b7315211-05d1-5889-b07c-4dd15e8c83eb",
+  "name": "To make orange fizz, Noah mixes 4 scoops&#xA0;of powder...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/14844",
+  "dateCreated": "2019-05-20 07:56:41 UTC",
+  "dateModified": "2021-10-19 14:21:26 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">ShortAnswerResponse</div>
+    <div class="AssessmentProblem.statement"><p>To make orange fizz, Noah mixes 4 scoops of powder with 6 cups of water. Andre mixes 5 scoops of powder with 8 cups of water.&#xA0;</p>
+
+<ol>
+	<li>Create a double number line or a table that shows different amounts of powder and water that taste the same as Noah&#x2019;s mixture.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>Create a double number line or a table that shows different amounts of powder and water that taste the same as Andre&#x2019;s mixture.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>How do their two mixtures compare in taste? Explain your reasoning.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><p>Representations vary in both kind and in the numbers used. Sample response:</p>
+
+<div>
+<div>
+<div>
+<p>Noah&#x2019;s recipe</p>
+</div>
+
+<div>
+<p>Andre&#x2019;s recipe</p>
+</div>
+</div>
+
+<div>
+<div spellcheck="false">
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">scoops of powder</th>
+			<th scope="col">cups of water</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>4</td>
+			<td>6</td>
+		</tr>
+		<tr>
+			<td>2</td>
+			<td>3</td>
+		</tr>
+		<tr>
+			<td>1</td>
+			<td>1.5</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+
+<div spellcheck="false">
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">scoops of powder</th>
+			<th scope="col">cups of water</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>5</td>
+			<td>8</td>
+		</tr>
+		<tr>
+			<td>10</td>
+			<td>16</td>
+		</tr>
+		<tr>
+			<td>1</td>
+			<td>1.6</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+</div>
+</div>
+
+<p>Noah&#x2019;s recipe tastes stronger. Sample reasoning: As shown in the tables, Noah&#x2019;s recipe uses less water for the same amount of powder.</p>
+
+<p>Minimal Tier 1 response:</p>
+
+<ul>
+	<li>Work is complete and correct, with complete explanation or justification.</li>
+	<li>Acceptable errors: some mixing up of the terms &#x201C;cup&#x201D; and &#x201C;scoop.&#x201D;</li>
+	<li>Sample:</li>
+</ul>
+
+<ol>
+	<li>See table for Noah&#x2019;s recipe.</li>
+	<li>See table for Andre&#x2019;s recipe.</li>
+	<li>Noah&#x2019;s tastes stronger because for him, 1 cup of water needs <span><annotation description="\(\frac23\)"/></span> of a scoop of powder, but for Andre, 1 cup of water needs only <span><annotation description="\(\frac58\)"/></span> of a scoop of powder.</li>
+</ol>
+
+<p>Tier 2 response:</p>
+
+<ul>
+	<li>Work shows good conceptual understanding and mastery, with either minor errors or correct work with insufficient explanation or justification.</li>
+	<li>Acceptable errors: a good explanation to part c is based on incorrect powder/water combinations found in parts a and b.</li>
+	<li>Sample errors: arithmetic errors in otherwise reasonable tables/double number lines; explanation for part c is on track but leaves the reader to connect too many dots, e.g., &#x201C;Noah&#x2019;s tastes stronger because <span><annotation description="\(\frac23 &gt;\frac58\)"/></span>.&#x201D;</li>
+</ul>
+
+<p>Tier 3 response:</p>
+
+<ul>
+	<li>Work shows a developing but incomplete conceptual understanding, with significant errors.</li>
+	<li>Acceptable errors: a good explanation to part c is based on incorrect powder/water combinations found in parts a and b.</li>
+	<li>Sample errors: Representations in parts a and b do not show evidence of an understanding of equivalent ratios; correct representations in parts a and b but explanation in part c is missing or does not involve a comparison of unit rates.</li>
+</ul>
+
+<p>Tier 4 response:</p>
+
+<ul>
+	<li>Work includes major errors or omissions that demonstrate a lack of conceptual understanding and mastery.</li>
+	<li>Sample errors: None of the work contains evidence of an understanding of equivalent ratios.</li>
+</ul>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-244853.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-244853.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+    "name": "To make orange fizz, Noah mixes 4 scoops&#xA0;of powder...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266331.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266331.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "name": "Here are three fractions: \\(\\frac{3}{4}\\), \\(\\frac{5}{6}\\), \\(\\frac{6}{8}\\). Two of these...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266331.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266331.ocx.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:6a95241a-ff78-5aea-925b-1a1381f475eb",
+  "identifier": "im:6a95241a-ff78-5aea-925b-1a1381f475eb",
+  "name": "Here are three fractions: \\(\\frac{3}{4}\\), \\(\\frac{5}{6}\\), \\(\\frac{6}{8}\\). Two of these...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/1996",
+  "dateCreated": "2018-08-18 23:47:12 UTC",
+  "dateModified": "2020-06-24 16:36:49 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p>Here are three fractions: <span><annotation description="\(\frac{3}{4}\)"/></span>, <span><annotation description="\(\frac{5}{6}\)"/></span>, <span><annotation description="\(\frac{6}{8}\)"/></span>. Two of these fractions are equivalent to each other. Which two? Explain or show your reasoning.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/4.tag"/></p>
+</div>
+    <div class="AssessmentProblem.solution"><p><span><annotation description="\(\frac{3}{4}\)"/></span> and <span><annotation description="\(\frac{6}{8}\)"/></span> are equivalent to each other. Possible strategies:</p>
+
+<ul>
+	<li>3 and 4 can be multiplied by 2 to get 6 and 8.</li>
+	<li>Here is a diagram:<img src="https://staging-cms-assets.illustrativemathematics.org/4sy2C8kNuCK8GgWB3FFJ9VdJ"/>
+</li>
+</ul>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266332.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266332.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "name": "42 is 6 times what number?4 is 28 times...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266332.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266332.ocx.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:650da8cc-5579-56c7-9c36-a73164bd9ed3",
+  "identifier": "im:650da8cc-5579-56c7-9c36-a73164bd9ed3",
+  "name": "42 is 6 times what number?4 is 28 times...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/1997",
+  "dateCreated": "2018-08-18 23:47:14 UTC",
+  "dateModified": "2020-06-24 16:36:50 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><ol>
+	<li>42 is 6 times what number?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>4 is 28 times what number?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>700 is 7 times what number?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Choose one part and explain how you know your answer is correct.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><ol>
+	<li>7</li>
+	<li><span><annotation description="\(\frac{1}{7}\)"/></span></li>
+	<li>100</li>
+	<li>Explanations vary.</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266333.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266333.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "name": "Label each tick mark with its location on the number...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266333.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266333.ocx.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:d915e0dd-522a-5f87-9350-8db00cd8012d",
+  "identifier": "im:d915e0dd-522a-5f87-9350-8db00cd8012d",
+  "name": "Label each tick mark with its location on the number...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/1998",
+  "dateCreated": "2018-08-18 23:47:15 UTC",
+  "dateModified": "2020-05-04 20:23:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p>Label each tick mark with its location on the number line:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/Q1QNLdvSXCk73afGAyjBrHN3"/></p>
+</div>
+    <div class="AssessmentProblem.solution"><p>Each tick mark should be labeled with a multiple of 3 (3, 6, 9, 12, etc.).</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266334.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266334.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "name": "Here is a number line:",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266334.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266334.ocx.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:4e72bfb8-89b7-5bb9-9ec5-cf9ac048642f",
+  "identifier": "im:4e72bfb8-89b7-5bb9-9ec5-cf9ac048642f",
+  "name": "Here is a number line:",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/1999",
+  "dateCreated": "2018-08-18 23:47:16 UTC",
+  "dateModified": "2020-06-24 16:36:52 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p><presentation-tag src="/presentation_tags/1.tag"/>Here is a number line:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/YYcujC3sZ3i1JASXVuEw3x5L"/></p>
+
+<ol>
+	<li>Write the number at <span><annotation description="\(A\)"/></span> as a fraction.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Write the number at <span><annotation description="\(A\)"/></span> as an equivalent fraction.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><ol>
+	<li>
+<span><annotation description="\(\frac{1}{3}\)"/></span>&#xA0;(or equivalent)</li>
+	<li>
+<span><annotation description="\(\frac{2}{6}\)"/></span>&#xA0;(or equivalent, but different from previous answer)</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266335.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266335.ocx.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:82184926-89dd-55c5-95be-b22b45aa1b97",
+  "identifier": "im:82184926-89dd-55c5-95be-b22b45aa1b97",
+  "name": "One batch of cookies calls for 1 bag of mix...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/2000",
+  "dateCreated": "2018-08-18 23:47:17 UTC",
+  "dateModified": "2020-06-24 16:36:51 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">ShortAnswerResponse</div>
+    <div class="AssessmentProblem.statement"><p>One batch of cookies calls for 1 bag of mix and the ingredients shown in the table.</p>
+
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="row">type of cookie</th>
+			<th scope="col">eggs</th>
+			<th scope="col">water</th>
+			<th scope="col">oil</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th scope="row">regular</th>
+			<td>1 egg</td>
+			<td><span><annotation description="\(\frac18\)"/></span></td>
+			<td><span><annotation description="\(\frac13\)"/></span></td>
+		</tr>
+		<tr>
+			<th scope="row">cake-like</th>
+			<td>2 eggs</td>
+			<td><span><annotation description="\(\frac18\)"/></span></td>
+			<td><span><annotation description="\(\frac13\)"/></span></td>
+		</tr>
+	</tbody>
+</table>
+
+<ol>
+	<li>
+	<p>What amounts of eggs, water, and oil would you need for 2 batches of regular cookies?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/></p>
+	</li>
+	<li>
+	<p>What amounts of eggs, water, and oil would you need for 3 batches of cake-like cookies?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/></p>
+	</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><ol>
+	<li>2 eggs, <span><annotation description="\(\frac{1}{4}\)"/></span> cup water, <span><annotation description="\(\frac{2}{3}\)"/></span> cup oil (or equivalent)</li>
+	<li>6 eggs, <span><annotation description="\(\frac{3}{8}\)"/></span> cup water, 1 cup oil (or equivalent)</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266335.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266335.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "name": "One batch of cookies calls for 1 bag of mix...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266336.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266336.ocx.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:a36141a6-f7fb-5ae5-a84d-9e00fe395cfe",
+  "identifier": "im:a36141a6-f7fb-5ae5-a84d-9e00fe395cfe",
+  "name": "Which skateboarder is faster: Jada who travels 2 miles in...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/2001",
+  "dateCreated": "2018-08-18 23:47:18 UTC",
+  "dateModified": "2020-05-04 20:23:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p>Which skateboarder is faster: Jada, who travels 2 miles in 12 minutes at a constant speed, or Clare, who travels 2 miles in 10 minutes at a constant speed? Explain how you know.</p>
+</div>
+    <div class="AssessmentProblem.solution"><p>Clare is faster because she covers the same distance as Jada in less time.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266336.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266336.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+    "name": "Which skateboarder is faster: Jada who travels 2 miles in...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266338.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266338.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:6d3d3aab-2e8d-552d-a488-877660321380",
+  "identifier": "im:6d3d3aab-2e8d-552d-a488-877660321380",
+  "name": "Select all the true statements.IMAGE NEEDED see mockupThe...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/2002",
+  "dateCreated": "2018-08-19 00:11:58 UTC",
+  "dateModified": "2020-06-24 16:36:57 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">MultipleSelectResponse</div>
+    <div class="AssessmentProblem.statement"><p>Select <strong>all</strong> the true statements.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/5wU5MmNaKU7Lo5A1GVkfN8Jj"/></p>
+</div>
+    <div class="AssessmentProblem.solution">["B", "D", "E"]</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266338.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266338.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "name": "Select all the true statements.IMAGE NEEDED see mockupThe...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266339.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266339.ocx.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:b0e5ec1a-aeb3-5b8f-bfd6-bb2c2aee675c",
+  "identifier": "im:b0e5ec1a-aeb3-5b8f-bfd6-bb2c2aee675c",
+  "name": "Select all the ratios that are equivalent to \\(9:6\\)\\(6:9\\)...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/2003",
+  "dateCreated": "2018-08-19 00:11:59 UTC",
+  "dateModified": "2020-06-24 16:36:59 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">MultipleSelectResponse</div>
+    <div class="AssessmentProblem.statement"><p>Select <strong>all</strong> the ratios that are equivalent to <span><annotation description="\(9:6\)"/></span>.</p>
+</div>
+    <div class="AssessmentProblem.solution">["B", "E"]</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266339.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266339.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "name": "Select all the ratios that are equivalent to \\(9:6\\)\\(6:9\\)...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266340.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266340.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "name": "A mixture of orange paint contains 8 teaspoons of red...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266340.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266340.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:688bdfdd-efa9-574c-aaee-7ff06ad1ad16",
+  "identifier": "im:688bdfdd-efa9-574c-aaee-7ff06ad1ad16",
+  "name": "A mixture of orange paint contains 8 teaspoons of red...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/2004",
+  "dateCreated": "2018-08-19 00:12:00 UTC",
+  "dateModified": "2020-05-06 16:34:50 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">MultipleChoiceResponse</div>
+    <div class="AssessmentProblem.statement"><p>A mixture of orange paint contains 8 teaspoons of red paint and 12 teaspoons of yellow paint. To make the same shade of orange paint using 18 teaspoons of red paint, how much yellow paint would you need? Use the double number line diagram to help if needed.<presentation-tag src="/presentation_tags/1.tag"/><presentation-tag src="/presentation_tags/1.tag"/></p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/G3MqNucsVjbPJdYkWN6sdc3y"/></p>
+</div>
+    <div class="AssessmentProblem.solution">0</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266341.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266341.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "name": "Elena rode her bike 2 miles in 10 minutes. She...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266341.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266341.ocx.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:a8ef9c03-d1d8-56e5-b817-78f360287a2f",
+  "identifier": "im:a8ef9c03-d1d8-56e5-b817-78f360287a2f",
+  "name": "Elena rode her bike 2 miles in 10 minutes. She...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/2005",
+  "dateCreated": "2018-08-19 00:12:00 UTC",
+  "dateModified": "2020-05-06 16:34:51 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p>Elena rode her bike 2 miles in 10 minutes. She rode at a constant speed. Complete the table to show the time it took her to travel different distances at this speed.&#xA0;</p>
+
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">distance traveled (miles)&#xA0;</th>
+			<th scope="col">elapsed time (minutes)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td style="text-align:center">2</td>
+			<td style="text-align:center">10</td>
+		</tr>
+		<tr>
+			<td style="text-align:center">1</td>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td style="text-align:center">1</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+    <div class="AssessmentProblem.solution"><table border="1">
+	<thead>
+		<tr>
+			<th scope="col">distance traveled (miles)&#xA0;</th>
+			<th scope="col">elapsed time (minutes)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td style="text-align:center">2</td>
+			<td style="text-align:center">10</td>
+		</tr>
+		<tr>
+			<td style="text-align:center">1</td>
+			<td style="text-align:center">5</td>
+		</tr>
+		<tr>
+			<td style="text-align:center">
+<span><annotation description="\(\frac15\)"/></span> or equivalent</td>
+			<td style="text-align:center">1</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266342.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266342.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "name": "3 concert tickets cost \\$45. At this rate, what is...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266342.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266342.ocx.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:3523ae0f-e19d-523e-974e-435ae861afbc",
+  "identifier": "im:3523ae0f-e19d-523e-974e-435ae861afbc",
+  "name": "3 concert tickets cost \\$45. At this rate, what is...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/2006",
+  "dateCreated": "2018-08-19 00:12:01 UTC",
+  "dateModified": "2020-06-25 11:57:57 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">ShortAnswerResponse</div>
+    <div class="AssessmentProblem.statement"><ol>
+	<li>
+	<p>Three concert tickets cost <span>$</span>45. At this rate, what is the cost per ticket?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/></p>
+	<presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>
+	<p>Three milkshakes cost <span>$</span>9.75. At this rate, how much do 2 milkshakes cost?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/></p>
+	<presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Three oranges cost <span>$</span>1.35. At this rate, how much do 5 oranges cost?<presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/><presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><ol>
+	<li>
+<span>$</span>15</li>
+	<li>
+<span>$</span>6.50</li>
+	<li>
+<span>$</span>2.25</li>
+</ol>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266343.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266343.ocx.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:ba85508b-d81a-57eb-a050-ad5796e4c3fb",
+  "identifier": "im:ba85508b-d81a-57eb-a050-ad5796e4c3fb",
+  "name": "A bag contains 150 marbles. Some are blue and the...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/2007",
+  "dateCreated": "2018-08-19 00:12:02 UTC",
+  "dateModified": "2020-05-06 16:34:52 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">RestrictedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p>A bag contains 150 marbles. Some are blue, and the rest are white. There are 21 blue marbles for every 4 white marbles. How many blue marbles are in the bag? Explain your reasoning.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/></p>
+</div>
+    <div class="AssessmentProblem.solution"><p>126 blue marbles. Explanations vary. Sample explanation: Make a table in which the first row has 21 blue marbles and 4 white marbles. We want to find the row where the total number of marbles is 150. Multiplying the first row by 6 gives 126 blue marbles and 24 white marbles, which add to the correct total of 150.</p>
+
+<p>Minimal Tier 1 response:</p>
+
+<ul>
+	<li>Work is complete and correct.</li>
+	<li>Sample: <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>21</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>6</mn>
+  <mo>=</mo>
+  <mn>126</mn>
+</math><annotation description="\(21\boldcdot6=126\)"/></span>, so there are 126 blue marbles and 24 white marbles.</li>
+</ul>
+
+<p>Tier 2 response:</p>
+
+<ul>
+	<li>Work shows general conceptual understanding and mastery, with some errors.</li>
+	<li>Sample errors: blue and white marbles are in the correct ratio but do not total 150; correct answer with no work shown and no explanation; work involves some correct reasoning about equivalent ratios with some errors.</li>
+</ul>
+
+<p>Tier 3 response:</p>
+
+<ul>
+	<li>Significant errors in work demonstrate lack of conceptual understanding or mastery.</li>
+	<li>Sample errors: Work does not show evidence of an understanding of equivalent ratios; incorrect answer with no work shown.</li>
+</ul>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266343.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266343.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "name": "A bag contains 150 marbles. Some are blue and the...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/assessment-problem-node-266344.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266344.ocx.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:AssessmentProblem",
+  "@id": "im:812dc393-8170-5d82-b501-2c3e8705b3a2",
+  "identifier": "im:812dc393-8170-5d82-b501-2c3e8705b3a2",
+  "name": "To make fruit punch, Priya mixes 3 scoops of powder...",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Assessment",
+    "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Assessment problem"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:AssessmentProblem",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/assessment_problems/2008",
+  "dateCreated": "2018-08-19 00:12:03 UTC",
+  "dateModified": "2021-10-19 14:22:55 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="AssessmentProblem.type">ExtendedConstructedResponse</div>
+    <div class="AssessmentProblem.statement"><p>To make fruit punch, Priya mixes 3 scoops of powder with 5 cups of water. Mai mixes 4 scoops of powder with 6 cups of water.</p>
+
+<ol>
+	<li>Create a double number line or a table that shows different amounts of powder and water that taste the same as Priya&#x2019;s mixture.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>Create a double number line or a table that shows different amounts of powder and water that taste the same as Mai&#x2019;s mixture.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>How do their two mixtures compare in taste? Explain your reasoning.</li>
+</ol>
+</div>
+    <div class="AssessmentProblem.solution"><p>Representations vary in both kind and in the numbers used. Sample response:</p>
+
+<div>
+<div>
+<div>
+<p>Priya&#x2019;s recipe&#xA0;</p>
+</div>
+
+<div>
+<p>Mai&#x2019;s recipe&#xA0;</p>
+</div>
+</div>
+
+<div>
+<div>
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">scoops of powder&#xA0;</th>
+			<th scope="col">&#xA0;cups of water</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td style="text-align:center">3</td>
+			<td style="text-align:center">5</td>
+		</tr>
+		<tr>
+			<td style="text-align:center">6</td>
+			<td style="text-align:center">10</td>
+		</tr>
+		<tr>
+			<td style="text-align:center">9</td>
+			<td style="text-align:center">15</td>
+		</tr>
+		<tr>
+			<td style="text-align:center">12</td>
+			<td style="text-align:center">20</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+
+<div>
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">scoops of powder&#xA0;</th>
+			<th scope="col">&#xA0;cups of water</th>
+		</tr>
+		<tr>
+			<td style="text-align:center">4</td>
+			<td style="text-align:center">6</td>
+		</tr>
+		<tr>
+			<td style="text-align:center">8</td>
+			<td style="text-align:center">12</td>
+		</tr>
+		<tr>
+			<td style="text-align:center">12</td>
+			<td style="text-align:center">18</td>
+		</tr>
+	</thead>
+</table>
+</div>
+</div>
+</div>
+
+<p><span style="font-family:-apple-system,BlinkMacSystemFont,&quot;Segoe UI&quot;,Roboto,&quot;Helvetica Neue&quot;,Arial,&quot;Noto Sans&quot;,sans-serif; font-size:0.875rem">Sample:</span>Mai&#x2019;s recipe tastes stronger. Sample reasoning: As shown in the tables, Mai&#x2019;s recipe uses less water for the same amount of powder at 12 scoops.</p>
+
+<p>Minimal Tier 1 response:</p>
+
+<ul>
+	<li>Work is complete and correct, with complete explanation or justification.</li>
+	<li>Acceptable errors: some mixing up of the terms &#x201C;cup&#x201D; and &#x201C;scoop.&#x201D;</li>
+</ul>
+
+<ul>
+	<li>
+	<ul>
+		<li>See table for Priya&#x2019;s recipe.</li>
+		<li>See table for Mai&#x2019;s recipe.</li>
+		<li>Mai&#x2019;s tastes stronger because more powder is used per cup, 1 cup of water needs <span><annotation description="\(\frac23\)"/></span> of a scoop of powder, but for Priya, 1 cup of water needs only <span><annotation description="\(\frac35\)"/></span> of a scoop of powder and <span><annotation description="\(\frac23\)"/></span> is greater than <span><annotation description="\(\frac35\)"/></span>.</li>
+	</ul>
+	</li>
+</ul>
+
+<p>Tier 2 response:</p>
+
+<ul>
+	<li>Work shows good conceptual understanding and mastery, with either minor errors or correct work with insufficient explanation or justification.</li>
+	<li>Acceptable errors: a good explanation to part c is based on incorrect powder/water combinations found in parts a and b.</li>
+	<li>Sample errors: arithmetic errors in otherwise reasonable tables/double number lines; explanation for part c is on track but leaves the reader to connect too many dots, e.g., &#x201C;Mai&#x2019;s tastes stronger because <span><annotation description="\(\frac23 &gt;\frac35\)"/></span>.&#x201D;</li>
+</ul>
+
+<p>Tier 3 response:</p>
+
+<ul>
+	<li>Work shows a developing but incomplete conceptual understanding, with significant errors.</li>
+	<li>Acceptable errors: a good explanation to part c is based on incorrect powder/water combinations found in parts a and b.</li>
+	<li>Sample errors: Representations in parts a and b do not show evidence of an understanding of equivalent ratios; correct representations in parts a and b but explanation in part c is missing or does not involve a comparison of unit rates.</li>
+</ul>
+
+<p>Tier 4 response:</p>
+
+<ul>
+	<li>Work includes major errors or omissions that demonstrate a lack of conceptual understanding and mastery.</li>
+	<li>Sample errors: None of the work contains evidence of an understanding of equivalent ratios.</li>
+</ul>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/assessment-problem-node-266344.ocx.html
+++ b/build/cms_im-PR1142/assessment-problem-node-266344.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Assessment",
     "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+    "name": "To make fruit punch, Priya mixes 3 scoops of powder...",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Assessment problem"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244428.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244428.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "name": "A Collection of Animals",
     "courseCode": "6.2.1"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244428.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244428.ocx.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:ef041e93-e429-574d-a120-9b8e050666f1",
+  "identifier": "im:ef041e93-e429-574d-a120-9b8e050666f1",
+  "name": "A Collection of Animals",
+  "alternateName": "6.2.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "courseCode": "6.2.1"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-1-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/2972",
+  "dateCreated": "2020-03-02 16:17:44 UTC",
+  "dateModified": "2020-08-18 15:01:16 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">A Collection of Animals</div>
+    <div class="im_statement"><p>Here is a collection of dogs, mice, and cats:</p>
+
+<figure><img src="https://staging-cms-assets.illustrativemathematics.org/RbuCkf8AAki3ignNB2ui878g"/></figure>
+
+<p>Write <em>two</em> sentences that describe a ratio of types of animals in this collection.</p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244458.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244458.ocx.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:b2e6fecc-d641-5074-aa05-a0d7796be716",
+  "identifier": "im:b2e6fecc-d641-5074-aa05-a0d7796be716",
+  "name": "Paws, Ears, and Tails",
+  "alternateName": "6.2.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "courseCode": "6.2.2"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-2-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/2984",
+  "dateCreated": "2020-03-02 16:17:45 UTC",
+  "dateModified": "2020-08-18 15:01:29 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Paws, Ears, and Tails</div>
+    <div class="im_statement"><p>There are 3 cats in a room and no other creatures. Each cat has 2 ears, 4 paws, and 1 tail.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/xRpd6sWcVAJMmqa1oZ6Zydk5"/></p>
+
+<ol>
+	<li>Draw a diagram that shows an association between numbers of ears, paws, and tails in the room.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>
+	<p>Complete each statement:</p>
+
+	<ol>
+		<li>The ratio of ______________ to ______________ to ______________ is ______ : _______ : ______.</li>
+		<li>There are ______ paws for every tail.</li>
+		<li>There are ______ paws for every ear.</li>
+	</ol>
+	</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244458.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244458.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "name": "Paws, Ears, and Tails",
     "courseCode": "6.2.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244481.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244481.ocx.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:56d8118d-517a-52b4-b57a-ed2d0bdc6183",
+  "identifier": "im:56d8118d-517a-52b4-b57a-ed2d0bdc6183",
+  "name": "A Smaller Batch of Bird Food",
+  "alternateName": "6.2.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "courseCode": "6.2.3"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-3-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/2996",
+  "dateCreated": "2020-03-02 16:17:46 UTC",
+  "dateModified": "2020-08-18 15:01:49 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">A Smaller Batch of Bird Food</div>
+    <div class="im_statement"><p>Usually when Elena makes bird food, she mixes 9 cups of seeds with 6 tablespoons of maple syrup. However, today&#xA0;she is short on ingredients. Think of a recipe that would yield a smaller batch of bird food but still taste the same. Explain or show your reasoning.</p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244481.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244481.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "name": "A Smaller Batch of Bird Food",
     "courseCode": "6.2.3"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244510.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244510.ocx.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:37cc331e-69fa-5154-be85-cb9c08ae6d34",
+  "identifier": "im:37cc331e-69fa-5154-be85-cb9c08ae6d34",
+  "name": "Orange Water",
+  "alternateName": "6.2.4",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "courseCode": "6.2.4"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-4-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3006",
+  "dateCreated": "2020-03-02 16:17:46 UTC",
+  "dateModified": "2020-08-18 15:02:04 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Orange Water</div>
+    <div class="im_statement"><p>A recipe for orange water says, &#x201C;Mix 3 teaspoons yellow water with 1 teaspoon red water.&#x201D; For this recipe, we might say: &#x201C;The ratio of teaspoons of yellow water to teaspoons of red water is <span><annotation description="\(3:1\)"/></span>.&#x201D;</p>
+
+<ol>
+	<li>Write a ratio for 2 batches of this recipe.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Write a ratio for 4 batches of this recipe.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Explain why we can say that any two of these three ratios are equivalent.</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244510.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244510.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "name": "Orange Water",
     "courseCode": "6.2.4"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244538.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244538.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "name": "Why Are They Equivalent?",
     "courseCode": "6.2.5"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244538.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244538.ocx.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:644ac22b-7421-5fb2-b934-26558893fa3e",
+  "identifier": "im:644ac22b-7421-5fb2-b934-26558893fa3e",
+  "name": "Why Are They Equivalent?",
+  "alternateName": "6.2.5",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "courseCode": "6.2.5"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-5-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3032",
+  "dateCreated": "2020-03-02 16:17:48 UTC",
+  "dateModified": "2020-10-01 14:05:47 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Why Are They Equivalent?</div>
+    <div class="im_statement"><ol>
+	<li>Write another ratio that is equivalent to the ratio <span><annotation description="\(4:6\)"/></span>.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How do you know that your new ratio is equivalent to <span><annotation description="\(4:6\)"/></span>? Explain or show your reasoning.</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244565.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244565.ocx.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:0cafcc56-0333-5db1-b5b1-414fe6a56654",
+  "identifier": "im:0cafcc56-0333-5db1-b5b1-414fe6a56654",
+  "name": "Batches of Cookies on a Double Number Line",
+  "alternateName": "6.2.6",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "courseCode": "6.2.6"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-6-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3049",
+  "dateCreated": "2020-03-02 16:17:49 UTC",
+  "dateModified": "2020-08-18 15:03:31 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Batches of Cookies on a Double Number Line</div>
+    <div class="im_statement"><p>A recipe for one batch of cookies uses 5 cups of flour and 2 teaspoons of vanilla.</p>
+
+<ol>
+	<li>Complete the double number line diagram to show the amount of flour and vanilla needed for 1, 2, 3, 4, and 5 batches of cookies.<img src="https://staging-cms-assets.illustrativemathematics.org/hFicdzsGwvx5SWXV8CDdowYo"/>
+</li>
+	<li>If you use 20 cups of flour, how many teaspoons of vanilla should you use?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>If you use 6 teaspoons of vanilla, how many cups of flour should you use?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244565.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244565.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "name": "Batches of Cookies on a Double Number Line",
     "courseCode": "6.2.6"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244587.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244587.ocx.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:9135a86c-691d-52af-82c7-83104c07abc8",
+  "identifier": "im:9135a86c-691d-52af-82c7-83104c07abc8",
+  "name": "Revisiting Paws, Ears, and Tails",
+  "alternateName": "6.2.7",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "courseCode": "6.2.7"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-7-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3075",
+  "dateCreated": "2020-03-02 16:17:50 UTC",
+  "dateModified": "2020-08-18 15:03:50 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Revisiting Paws, Ears, and Tails</div>
+    <div class="im_statement"><p>Each of these cats has 2 ears, 4 paws, and 1 tail.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/xRpd6sWcVAJMmqa1oZ6Zydk5"/></p>
+
+<ol>
+	<li>Draw a double number line diagram that represents a ratio in the situation.<presentation-tag src="/presentation_tags/5.tag"/><presentation-tag src="/presentation_tags/5.tag"/>
+</li>
+	<li>Write a sentence that describes this situation and that uses the word <em>per</em>.</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244587.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244587.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "name": "Revisiting Paws, Ears, and Tails",
     "courseCode": "6.2.7"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244611.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244611.ocx.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:c6c6447b-09c1-5864-967c-607a488b4fd9",
+  "identifier": "im:c6c6447b-09c1-5864-967c-607a488b4fd9",
+  "name": "Unit Price of Rice",
+  "alternateName": "6.2.8",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "courseCode": "6.2.8"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-8-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3098",
+  "dateCreated": "2020-03-02 16:17:52 UTC",
+  "dateModified": "2020-08-18 15:04:24 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Unit Price of Rice</div>
+    <div class="im_statement"><p>Here is a double number line showing that it costs <span>$</span>3&#xA0;to buy 2 bags of rice:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/q6roPSEYnf55DPcuMWe3gJGX"/></p>
+
+<ol>
+	<li>At this rate, how many bags of rice can you buy with <span>$</span>12?<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>Find the cost per bag.<presentation-tag src="/presentation_tags/3.tag"/><presentation-tag src="/presentation_tags/3.tag"/>
+</li>
+	<li>How much do 20 bags of rice cost?</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244611.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244611.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "name": "Unit Price of Rice",
     "courseCode": "6.2.8"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244636.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244636.ocx.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:124ec28d-3284-5ed0-9b6f-f47db7223119",
+  "identifier": "im:124ec28d-3284-5ed0-9b6f-f47db7223119",
+  "name": "Train Speeds",
+  "alternateName": "6.2.9",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "courseCode": "6.2.9"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-9-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3110",
+  "dateCreated": "2020-03-02 16:17:52 UTC",
+  "dateModified": "2020-08-18 15:04:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Train Speeds</div>
+    <div class="im_statement"><p>Two trains are traveling at constant speeds on different tracks.</p>
+
+<p>Train A:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/83wn6rw6pjUgrgSRB7kQBtro"/></p>
+
+<p>Train B:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/5vNWjrZaWV2jrZunmRE3G3WT"/></p>
+
+<p>Which train is traveling faster? Explain your reasoning.</p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244636.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244636.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "name": "Train Speeds",
     "courseCode": "6.2.9"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244664.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244664.ocx.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:ca6e2c4b-5dc4-5555-bb7d-f8b61512c248",
+  "identifier": "im:ca6e2c4b-5dc4-5555-bb7d-f8b61512c248",
+  "name": "Comparing Runs",
+  "alternateName": "6.2.10",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "courseCode": "6.2.10"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-10-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3118",
+  "dateCreated": "2020-03-02 16:17:53 UTC",
+  "dateModified": "2020-08-18 15:04:50 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Comparing Runs</div>
+    <div class="im_statement"><p>Andre ran 2 kilometers in 15 minutes, and Jada ran 3 kilometers in 20 minutes. Both ran at a constant speed.</p>
+
+<p>Did they run at the <em>same</em> speed? Explain your reasoning.</p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244664.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244664.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "name": "Comparing Runs",
     "courseCode": "6.2.10"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244690.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244690.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "name": "Batches of Cookies in a Table",
     "courseCode": "6.2.11"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244690.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244690.ocx.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:6743a009-d76a-5ad8-8cf4-94112c86a8f9",
+  "identifier": "im:6743a009-d76a-5ad8-8cf4-94112c86a8f9",
+  "name": "Batches of Cookies in a Table",
+  "alternateName": "6.2.11",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "courseCode": "6.2.11"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-11-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3122",
+  "dateCreated": "2020-03-02 16:17:53 UTC",
+  "dateModified": "2020-08-18 15:05:08 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Batches of Cookies in a Table</div>
+    <div class="im_statement"><p>In previous lessons, we worked with a diagram and a double number line that represent this cookie recipe. Here is a table that represents the same situation.</p>
+
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">flour (cups)</th>
+			<th scope="col">vanilla (teaspoons)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>5</td>
+			<td>2</td>
+		</tr>
+		<tr>
+			<td>15</td>
+			<td>6</td>
+		</tr>
+		<tr>
+			<td><span><annotation description="\(2\frac12\)"/></span></td>
+			<td>1</td>
+		</tr>
+		<tr>
+			<td/>
+			<td/>
+		</tr>
+	</tbody>
+</table>
+
+<ol>
+	<li>Write a sentence that describes a ratio shown in the table.<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>What does the second row of numbers represent?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>Complete the last row for a different batch size that hasn&#x2019;t been used so far in the table. Explain or show your reasoning.</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244714.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244714.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "name": "Price of Bagels",
     "courseCode": "6.2.12"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244714.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244714.ocx.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:72770338-5ad4-5291-9115-de0b67c087a6",
+  "identifier": "im:72770338-5ad4-5291-9115-de0b67c087a6",
+  "name": "Price of Bagels",
+  "alternateName": "6.2.12",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "courseCode": "6.2.12"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-12-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3135",
+  "dateCreated": "2020-03-02 16:17:54 UTC",
+  "dateModified": "2020-08-18 15:05:20 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Price of Bagels</div>
+    <div class="im_statement"><p>A shop sells bagels for <span>$</span>5&#xA0;per dozen. You can use the table to answer the questions. Explain your reasoning.</p>
+
+<div>
+<div>
+<div>
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">number of bagels</th>
+			<th scope="col">price in dollars</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>12</td>
+			<td>5</td>
+		</tr>
+		<tr>
+			<td/>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td/>
+		</tr>
+		<tr>
+			<td/>
+			<td/>
+		</tr>
+	</tbody>
+</table>
+</div>
+
+<div>
+<ol>
+	<li>At this rate, how much would 6 bagels cost?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How many bagels can you buy for <span>$</span>50?</li>
+</ol>
+</div>
+</div>
+</div>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244744.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244744.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "name": "Bicycle Sprint",
     "courseCode": "6.2.13"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244744.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244744.ocx.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:7d2f763d-a167-5a2a-bf01-64dc7263604d",
+  "identifier": "im:7d2f763d-a167-5a2a-bf01-64dc7263604d",
+  "name": "Bicycle Sprint",
+  "alternateName": "6.2.13",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "courseCode": "6.2.13"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-13-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3136",
+  "dateCreated": "2020-03-02 16:17:54 UTC",
+  "dateModified": "2020-08-18 15:05:33 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Bicycle Sprint</div>
+    <div class="im_statement"><p>In a sprint to the finish, a professional cyclist travels 380 meters in 20 seconds. At that rate, how far does the cyclist travel in 3 seconds?</p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244768.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244768.ocx.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:e70c96fb-6e3c-556b-a67e-8dd54f76356a",
+  "identifier": "im:e70c96fb-6e3c-556b-a67e-8dd54f76356a",
+  "name": "Water Faucet",
+  "alternateName": "6.2.14",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "courseCode": "6.2.14"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-14-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3137",
+  "dateCreated": "2020-03-02 16:17:54 UTC",
+  "dateModified": "2020-08-18 15:05:47 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Water Faucet</div>
+    <div class="im_statement"><p>Jada wants to know how fast the water comes out of her faucet. What information would she need to know to be able to determine that?</p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244768.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244768.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "name": "Water Faucet",
     "courseCode": "6.2.14"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244790.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244790.ocx.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:ebed9736-a7ca-5bbd-954b-58322266adc3",
+  "identifier": "im:ebed9736-a7ca-5bbd-954b-58322266adc3",
+  "name": "Room Sizes",
+  "alternateName": "6.2.15",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "courseCode": "6.2.15"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-15-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3154",
+  "dateCreated": "2020-03-02 16:17:55 UTC",
+  "dateModified": "2020-08-18 15:06:07 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Room Sizes</div>
+    <div class="im_statement"><p>The first floor of a house consists of a kitchen, playroom, and dining room. The areas of the kitchen, playroom, and dining room are in the ratio <span><annotation description="\(4 : 3 : 2\)"/></span>. The combined area of these three rooms is 189 square feet. What is the area of each room?</p>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244790.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244790.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "name": "Room Sizes",
     "courseCode": "6.2.15"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/cool-down-node-244813.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244813.ocx.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:CoolDown",
+  "@id": "im:b2641bbf-5631-5851-b722-bc98f10c5ff3",
+  "identifier": "im:b2641bbf-5631-5851-b722-bc98f10c5ff3",
+  "name": "Pizza-making Party",
+  "alternateName": "6.2.16",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "courseCode": "6.2.16"
+  },
+  "learningResourceType": [
+    "Cool down"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:CoolDown",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "Grade6-2-16-CoolDown-cool-down.docx"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/cool_downs/3155",
+  "dateCreated": "2020-03-02 16:17:55 UTC",
+  "dateModified": "2020-08-18 15:06:20 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Activity.name">Pizza-making Party</div>
+    <div class="im_statement"><p>You are having a pizza-making party for a number of people. You will need 6 ounces of dough and 4 ounces of sauce for each person at this party. If you used a total of 130 ounces of dough and sauce all together,</p>
+
+<ol>
+	<li>How many ounces of dough were used at the party?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How many ounces of sauce were used at the party?<presentation-tag src="/presentation_tags/4.tag"/><presentation-tag src="/presentation_tags/4.tag"/>
+</li>
+	<li>How many people were at the party?&#xA0;</li>
+</ol>
+</div>
+    <div class="im_extension"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/cool-down-node-244813.ocx.html
+++ b/build/cms_im-PR1142/cool-down-node-244813.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "name": "Pizza-making Party",
     "courseCode": "6.2.16"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Cool down"
   ],

--- a/build/cms_im-PR1142/lesson-node-244424.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244424.ocx.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+  "identifier": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+  "name": "Introducing Ratios and Ratio Language",
+  "alternateName": "6.2.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:5a855ebc-4e35-52f2-bb33-4cc9e81e4174",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15514",
+  "dateCreated": "2019-05-20 07:43:17 UTC",
+  "dateModified": "2021-07-26 13:55:31 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Introducing Ratios and Ratio Language</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s describe&#xA0;two quantities at the same time.</p>
+</div>
+    <div class="im_learning_targets">I can write or say a sentence that describes a ratio.
+I know how to say words and numbers in the correct order to accurately describe the ratio.</div>
+    <div class="im_glossary_entries">ratio: <p>A ratio is an association between 2 or more quantities.</p>
+
+<div>
+<div>
+<div>
+<p>For example, the ratio <span><annotation description="\(3:2\)"/></span> could describe a recipe that uses 3 cups of flour for every 2 eggs, or a boat that moves 3 meters every 2 seconds. One way to represent the ratio <span><annotation description="\(3:2\)"/></span> is with a diagram that has 3 blue squares for every 2 green squares.</p>
+</div>
+
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/49l2pmuzhonlpn0w6waoycic7iap"/></p>
+</div>
+</div>
+</div>
+</div>
+    <div class="im_student_lesson_summary"><p>A <strong>ratio</strong> is an association between two or more quantities. There are many ways to describe a situation in terms of ratios. For example, look at this collection:</p>
+
+<div>
+<div>
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/39LcBfhTCGnta6YuE6UDHZjL"/></p>
+</div>
+
+<div>
+<p>Here are some correct ways to describe the collection:</p>
+
+<ul>
+	<li>The ratio of squares to circles is <span><annotation description="\(6:3\)"/></span>.</li>
+	<li>The ratio of circles to squares is 3 to 6.</li>
+</ul>
+</div>
+</div>
+</div>
+
+<p>Notice that the shapes can be arranged in equal groups, which allow us to describe the shapes using other numbers.</p>
+
+<div>
+<div>
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/wiqz6NhWWxWYiuJSyYJ12apx"/></p>
+</div>
+
+<div>
+<ul>
+	<li>There are 2 squares for every 1 circle.</li>
+	<li>There is 1 circle for every 2 squares.</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244424.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244424.ocx.html
@@ -35,8 +35,41 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:5a855ebc-4e35-52f2-bb33-4cc9e81e4174",
+    "name": "Introducing Ratios and Ratio Language",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:eedef24f-7f96-5d4a-b3ad-91fbc1427542",
+      "name": "What Kind and How Many?",
+      "alternateName": "6.2.1.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:93cbf6e6-11da-53df-bdfe-88a498c37c6f",
+      "name": "The Teacher&#x2019;s Collection",
+      "alternateName": "6.2.1.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:580a1985-11ef-5124-9948-90ed8e63b192",
+      "name": "The Student&#x2019;s Collection",
+      "alternateName": "6.2.1.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:08c0985d-2b0f-5cd3-aa82-35f4eaa5728b",
+      "name": "I can write or say a sentence that describes a ratio.",
+      "alternateName": "I can write or say a sentence that describes a ratio."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:9719ee4c-6122-5b9b-b6ed-31206f20bbb4",
+      "name": "I know how to say words and numbers in the correct order to accurately describe the ratio.",
+      "alternateName": "I know how to say words and numbers in the correct order to accurately describe the ratio."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244453.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244453.ocx.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+  "identifier": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+  "name": "Representing Ratios with Diagrams",
+  "alternateName": "6.2.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:5a855ebc-4e35-52f2-bb33-4cc9e81e4174",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15515",
+  "dateCreated": "2019-05-20 07:43:18 UTC",
+  "dateModified": "2021-07-26 14:01:57 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Representing Ratios with Diagrams</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s use diagrams to represent ratios.</p>
+</div>
+    <div class="im_learning_targets">I can draw a diagram that represents a ratio and explain what the diagram means.
+I include labels when I draw a diagram that represents a ratio, so that the meaning of the diagram is clear.</div>
+    <div class="im_glossary_entries"/>
+    <div class="im_student_lesson_summary"><p>Ratios can be represented using diagrams. The diagrams do not need to include realistic details. For example, a&#xA0;recipe for lemonade says, &#x201C;Mix 2 scoops of lemonade powder with 6 cups of water.&#x201D;</p>
+
+<p>Instead of this:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/dyXYLPKtdb9FiGENnmHLpubQ"/></p>
+
+<p>We can draw something like this:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/fGPQGfvpD9cJLpKo3j36ehch"/></p>
+
+<p>This diagram shows that the ratio of cups of water to scoops of lemonade powder is 6 to 2. We can also see that for every scoop of lemonade powder, there are 3 cups of water.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244453.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244453.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:5a855ebc-4e35-52f2-bb33-4cc9e81e4174",
+    "name": "Representing Ratios with Diagrams",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:7149595b-794b-5336-9a09-4938d4c89ff4",
+      "name": "Number Talk: Dividing by 4 and Multiplying by $\\frac14$",
+      "alternateName": "6.2.2.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:d0b60bd9-57ad-571c-8873-db70974555bd",
+      "name": "A Collection of Snap Cubes",
+      "alternateName": "6.2.2.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:29b412b2-774a-5983-ba51-77baa13303c4",
+      "name": "Blue Paint and Art Paste",
+      "alternateName": "6.2.2.3"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:57f0754f-1302-537e-9041-8896aeafd7a5",
+      "name": "Card Sort: Spaghetti Sauce",
+      "alternateName": "6.2.2.4"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:4940daf8-9022-53e7-aece-5f6d3c404659",
+      "name": "I can draw a diagram that represents a ratio and explain what the diagram means.",
+      "alternateName": "I can draw a diagram that represents a ratio and explain what the diagram means."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:8bf1d705-20ca-579e-a09a-8269c85ddf72",
+      "name": "I include labels when I draw a diagram that represents a ratio, so that the meaning of the diagram is clear.",
+      "alternateName": "I include labels when I draw a diagram that represents a ratio, so that the meaning of the diagram is clear."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244477.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244477.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:2ede255d-a6eb-5b61-a7b0-259eecd4ed0a",
+    "name": "Recipes",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:4f69d547-f41d-5088-8a03-08f583ddec21",
+      "name": "Flower Pattern",
+      "alternateName": "6.2.3.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:b931e3d8-ff69-5cea-a3d8-87885c3cee71",
+      "name": "Powdered Drink Mix",
+      "alternateName": "6.2.3.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:5f9fede3-f9cc-5639-8166-6b8f92a930a4",
+      "name": "Batches of Cookies",
+      "alternateName": "6.2.3.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:4aba6fd0-6238-5eb2-8279-01c679424fdf",
+      "name": "I can explain the meaning of equivalent ratios using a recipe as an example.",
+      "alternateName": "I can explain the meaning of equivalent ratios using a recipe as an example."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:21f8f68a-234c-5170-9960-63de77778548",
+      "name": "I can use a diagram to represent a recipe and to represent a double batch and a triple batch of the recipe.",
+      "alternateName": "I can use a diagram to represent a recipe and to represent a double batch and a triple batch of the recipe."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:64cd164a-82f8-5cec-bf79-84427428339a",
+      "name": "I know what it means to double or triple a recipe. ",
+      "alternateName": "I know what it means to double or triple a recipe. "
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244477.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244477.ocx.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+  "identifier": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+  "name": "Recipes",
+  "alternateName": "6.2.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:2ede255d-a6eb-5b61-a7b0-259eecd4ed0a",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15516",
+  "dateCreated": "2019-05-20 07:43:19 UTC",
+  "dateModified": "2021-07-26 14:05:54 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Recipes</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s explore how ratios affect the way a recipe tastes.</p>
+</div>
+    <div class="im_learning_targets">I can explain the meaning of equivalent ratios using a recipe as an example.
+I can use a diagram to represent a recipe and to represent a double batch and a triple batch of the recipe.
+I know what it means to double or triple a recipe. </div>
+    <div class="im_glossary_entries"/>
+    <div class="im_student_lesson_summary"><p>A recipe for&#xA0;fizzy juice says, &#x201C;Mix&#xA0;5 cups of cranberry juice with 2 cups of soda water.&#x201D;</p>
+
+<p>To double this recipe, we would use 10 cups of cranberry juice with 4 cups of soda water. To triple this recipe, we would use 15 cups of cranberry juice with 6 cups of soda water.</p>
+
+<p>This diagram&#xA0;shows a single&#xA0;batch of the recipe, a double batch, and a triple batch:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/pAc6mUN2vNQxtE5MGRDpXNfN"/></p>
+
+<p>We say that the ratios <span><annotation description="\(5 : 2\)"/></span>, <span><annotation description="\(10 : 4\)"/></span>, and <span><annotation description="\(15 : 6\)"/></span> are <strong>equivalent</strong>. Even though the amounts of each ingredient within a single, double, or triple batch are not the same, they would make fizzy juice that tastes the same.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244506.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244506.ocx.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+  "identifier": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+  "name": "Color Mixtures",
+  "alternateName": "6.2.4",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:2ede255d-a6eb-5b61-a7b0-259eecd4ed0a",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15517",
+  "dateCreated": "2019-05-20 07:43:19 UTC",
+  "dateModified": "2021-07-26 14:08:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Color Mixtures</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s see what color-mixing has to do with ratios.</p>
+</div>
+    <div class="im_learning_targets">I can explain the meaning of equivalent ratios using a color mixture as an example.
+I can use a diagram to represent a single batch, a double batch, and a triple batch of a color mixture.
+I know what it means to double or triple a color mixture. </div>
+    <div class="im_glossary_entries"/>
+    <div class="im_student_lesson_summary"><p>When mixing colors, doubling or tripling the amount of each color will create the same shade of the mixed color. In fact, you can always multiply the amount of <em>each</em> color by <em>the same number</em> to create a different amount of the same mixed color.</p>
+
+<p>For example, a batch of dark orange paint uses 4 ml of red paint and 2 ml of yellow paint.</p>
+
+<ul>
+	<li>To make two batches of dark orange paint, we can mix 8 ml of red paint with 4 ml of yellow paint.</li>
+	<li>To make three batches of dark orange paint, we can mix 12 ml of red paint with 6 ml of yellow paint.</li>
+</ul>
+
+<p>Here is a diagram that represents 1, 2, and 3 batches of this recipe.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/e42Kesdpeg8AXgzeUpddbHTM"/></p>
+
+<p>We say that the ratios <span><annotation description="\(4:2\)"/></span>, <span><annotation description="\(8:4\)"/></span>, and <span><annotation description="\(12:6\)"/></span> are <em>equivalent</em> because they describe&#xA0;the same color mixture in&#xA0;different numbers of batches, and they make the same shade of orange.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244506.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244506.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:2ede255d-a6eb-5b61-a7b0-259eecd4ed0a",
+    "name": "Color Mixtures",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:048b2bd1-a908-5899-b4b2-18e7de38252e",
+      "name": "Number Talk: Adjusting a Factor",
+      "alternateName": "6.2.4.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:3f6af204-e08e-57ba-a41f-27ad047f92eb",
+      "name": "Turning Green",
+      "alternateName": "6.2.4.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:ed6dddfb-800f-54ff-90de-4646efea9376",
+      "name": "Perfect Purple Water",
+      "alternateName": "6.2.4.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:723321b9-a35d-52e8-87bb-b6fdfced1454",
+      "name": "I can explain the meaning of equivalent ratios using a color mixture as an example.",
+      "alternateName": "I can explain the meaning of equivalent ratios using a color mixture as an example."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:3ff6cfb9-e3ec-5d1e-8dee-ba92f62f3032",
+      "name": "I can use a diagram to represent a single batch, a double batch, and a triple batch of a color mixture.",
+      "alternateName": "I can use a diagram to represent a single batch, a double batch, and a triple batch of a color mixture."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:0923e3a0-c491-537c-8de0-e8c9661caa33",
+      "name": "I know what it means to double or triple a color mixture. ",
+      "alternateName": "I know what it means to double or triple a color mixture. "
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244534.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244534.ocx.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+  "identifier": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+  "name": "Defining Equivalent Ratios",
+  "alternateName": "6.2.5",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:2ede255d-a6eb-5b61-a7b0-259eecd4ed0a",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15518",
+  "dateCreated": "2019-05-20 07:43:19 UTC",
+  "dateModified": "2021-07-26 14:10:00 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Defining Equivalent Ratios</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s investigate equivalent ratios some more.</p>
+</div>
+    <div class="im_learning_targets">If I have a ratio, I can create a new ratio that is equivalent to it.
+If I have two ratios, I can decide whether they are equivalent to each other.</div>
+    <div class="im_glossary_entries">equivalent ratios: <p>Two ratios are equivalent if each of the numbers in the first ratio can be multiplied by the same factor to get the numbers in the second ratio. For example, <span><annotation description="\(8:6\)"/></span> is equivalent to <span><annotation description="\(4:3\)"/></span>, because <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>8</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mfrac>
+    <mn>1</mn>
+    <mn>2</mn>
+  </mfrac>
+  <mo>=</mo>
+  <mn>4</mn>
+</math><annotation description="\(8\boldcdot\frac12 = 4\)"/></span> and <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>6</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mfrac>
+    <mn>1</mn>
+    <mn>2</mn>
+  </mfrac>
+  <mo>=</mo>
+  <mn>3</mn>
+</math><annotation description="\(6\boldcdot\frac12 = 3\)"/></span>.</p>
+
+<div>
+<div>
+<div>
+<p>A recipe for lemonade says to use&#xA0;8 cups of water and 6 lemons. If 4 cups of water and 3 lemons are used, it will make half as much lemonade. Both recipes taste the same, because <span><annotation description="\(8:6\)"/></span> and <span><annotation description="\(4:3\)"/></span> are equivalent ratios.</p>
+</div>
+
+<div>
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="col">cups of water</th>
+			<th scope="col">number of lemons</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>8</td>
+			<td>6</td>
+		</tr>
+		<tr>
+			<td>4</td>
+			<td>3</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+</div>
+</div>
+
+<p><presentation-tag src="/presentation_tags/3.tag"/></p>
+</div>
+    <div class="im_student_lesson_summary"><p>All ratios that are <strong>equivalent</strong> to <span><annotation description="\(a:b\)"/></span> can be made by multiplying both <span><annotation description="\(a\)"/></span> and <span><annotation description="\(b\)"/></span> by the same number.</p>
+
+<div>
+<div>
+<div>
+<p>For example, the ratio <span><annotation description="\(18:12\)"/></span> is equivalent to <span><annotation description="\(9:6\)"/></span> because both 9 and 6 are multiplied by the same number: 2.<presentation-tag src="/presentation_tags/3.tag"/></p>
+</div>
+
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/J7EDfX5KMs5wj6pfxzYxhQmC"/></p>
+</div>
+</div>
+
+<div>
+<div>
+<p><span><annotation description="\(3:2\)"/></span> is also equivalent to <span><annotation description="\(9:6\)"/></span>, because both 9 and 6 are multiplied by the same number: <span><annotation description="\(\frac13\)"/></span>.<presentation-tag src="/presentation_tags/3.tag"/></p>
+</div>
+
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/pN7oveqVLFaTVEqxnHRg2kyX"/></p>
+</div>
+</div>
+
+<div>
+<div>
+<p>Is <span><annotation description="\(18:15\)"/></span> equivalent to <span><annotation description="\(9:6\)"/></span>?</p>
+
+<p>No, because 18 is <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>9</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>2</mn>
+</math><annotation description="\(9 \boldcdot 2\)"/></span>, but 15 is <em>not </em><span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>6</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>2</mn>
+</math><annotation description="\(6 \boldcdot 2\)"/></span>.</p>
+</div>
+
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/paFPGgUz7CkCTYp7RuBuWmNm"/></p>
+</div>
+</div>
+</div>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244534.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244534.ocx.html
@@ -35,8 +35,41 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:2ede255d-a6eb-5b61-a7b0-259eecd4ed0a",
+    "name": "Defining Equivalent Ratios",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:0b4e7cb1-f917-571e-8a1e-f21ba5c61878",
+      "name": "Dots and Half Dots",
+      "alternateName": "6.2.5.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:3e579587-b9e8-5f5f-9585-5136542627d0",
+      "name": "Tuna Casserole",
+      "alternateName": "6.2.5.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:b131efa0-1022-55a9-ac94-57a447b93a3a",
+      "name": "What Are Equivalent Ratios?",
+      "alternateName": "6.2.5.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:80d77357-c2df-51b6-9cc8-9b58f19c3a9d",
+      "name": "If I have a ratio, I can create a new ratio that is equivalent to it.",
+      "alternateName": "If I have a ratio, I can create a new ratio that is equivalent to it."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:799d6115-d2dd-525a-9071-78d5d996c3fb",
+      "name": "If I have two ratios, I can decide whether they are equivalent to each other.",
+      "alternateName": "If I have two ratios, I can decide whether they are equivalent to each other."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244561.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244561.ocx.html
@@ -35,8 +35,41 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "name": "Introducing Double Number Line Diagrams",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:9590ad05-0fe2-5579-afd6-8f6f6959874c",
+      "name": "Number Talk: Adjusting Another Factor",
+      "alternateName": "6.2.6.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:52a029ea-c826-54ec-bec4-a0cb8eb8817d",
+      "name": "Drink Mix on a Double Number Line",
+      "alternateName": "6.2.6.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:b54acc83-b25a-56e8-9c21-d3b7a64d6fc8",
+      "name": "Blue Paint on a Double Number Line",
+      "alternateName": "6.2.6.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:b234f007-639c-5c9a-8a9d-03b8d7d53175",
+      "name": "I can label a double number line diagram to represent batches of a recipe or color mixture.",
+      "alternateName": "I can label a double number line diagram to represent batches of a recipe or color mixture."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:cac86c52-eedb-5204-89c9-8c7bbbe871d4",
+      "name": "When I have a double number line that represents a situation, I can explain what it means.",
+      "alternateName": "When I have a double number line that represents a situation, I can explain what it means."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244561.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244561.ocx.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+  "identifier": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+  "name": "Introducing Double Number Line Diagrams",
+  "alternateName": "6.2.6",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15519",
+  "dateCreated": "2019-05-20 07:43:19 UTC",
+  "dateModified": "2021-07-22 14:07:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Introducing Double Number Line Diagrams</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s use number lines to represent equivalent ratios.</p>
+</div>
+    <div class="im_learning_targets">I can label a double number line diagram to represent batches of a recipe or color mixture.
+When I have a double number line that represents a situation, I can explain what it means.</div>
+    <div class="im_glossary_entries">double number line diagram: <p>A double number line diagram uses a pair of parallel number lines to represent equivalent ratios. The locations of the tick marks match on both number lines. In the double number line diagram shown here, an example of equivalent ratios is 3:5 and 6:10. The tick marks labeled with a 0 line up, but the other numbers are usually different.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/asitmgtd8djymseg51631l41wo53"/></p>
+</div>
+    <div class="im_student_lesson_summary"><p>You can use a <strong>double number line diagram</strong> to find many equivalent ratios. For example, a recipe for fizzy juice says, &#x201C;Mix 5 cups of cranberry juice with 2 cups of soda water.&#x201D; The ratio of cranberry juice to soda water is <span><annotation description="\(5:2\)"/></span>. Multiplying both ingredients by the same number creates equivalent ratios.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/wZ4TX6R12Jax9NNWAgJ98mQo"/></p>
+
+<p>This double number line shows that the ratio <span><annotation description="\(20:8\)"/></span> is equivalent to <span><annotation description="\(5:2\)"/></span>. If you mix 20 cups of cranberry juice with 8 cups of soda water, it makes 4 times as much fizzy juice that tastes the same as the original recipe.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244582.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244582.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "name": "Creating Double Number Line Diagrams",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:a22df16a-4942-519b-ac07-231cbc990a86",
+      "name": "Ordering on a Number Line",
+      "alternateName": "6.2.7.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:0bd2e675-4eb5-56d8-8f63-e4035db81efc",
+      "name": "Just a Little Green",
+      "alternateName": "6.2.7.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:9ef8c28c-8258-591f-838b-aec738a37f0b",
+      "name": "Art Paste on a Double Number Line",
+      "alternateName": "6.2.7.3"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:42c9ba45-2821-5b32-90ef-5fbc3e7ced9f",
+      "name": "Revisiting Tuna Casserole",
+      "alternateName": "6.2.7.4"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:1b440605-2dce-5cdf-9827-7014ae19707d",
+      "name": "I can create a double number line diagram and correctly place and label tick marks to represent equivalent ratios.",
+      "alternateName": "I can create a double number line diagram and correctly place and label tick marks to represent equivalent ratios."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:1557a19b-1bd0-5437-abcd-a514fc99150b",
+      "name": "I can explain what the word \"per\" means.",
+      "alternateName": "I can explain what the word \"per\" means."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244582.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244582.ocx.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+  "identifier": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+  "name": "Creating Double Number Line Diagrams",
+  "alternateName": "6.2.7",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15520",
+  "dateCreated": "2019-05-20 07:43:19 UTC",
+  "dateModified": "2021-07-26 14:15:51 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Creating Double Number Line Diagrams</div>
+    <div class="im_student_facing_learning_goals"><p>Let's draw double number line diagrams like a pro.</p>
+</div>
+    <div class="im_learning_targets">I can create a double number line diagram and correctly place and label tick marks to represent equivalent ratios.
+I can explain what the word "per" means.</div>
+    <div class="im_glossary_entries">per: <p>The word &#x201C;per&#x201D; means &#x201C;for each.&#x201D; For example, if the price is \$5 per ticket, that means \$5 will be paid <em>for each</em> ticket. Buying 4 tickets would cost $20, because <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>4</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>5</mn>
+  <mo>=</mo>
+  <mn>20</mn>
+</math><annotation description="\(4 \boldcdot 5 = 20\)"/></span>.</p>
+</div>
+    <div class="im_student_lesson_summary"><p>Here are some guidelines to keep in mind when drawing a double number line diagram:</p>
+
+<ul>
+	<li>The two parallel lines should have labels that describe what the numbers represent.</li>
+	<li>The tick marks and numbers should be spaced at equal intervals.</li>
+	<li>Numbers that line up vertically make equivalent ratios.</li>
+</ul>
+
+<p>For example, the ratio of the number of eggs to cups of milk in a recipe is <span><annotation description="\(4:1\)"/></span>. Here is a&#xA0;double number line that represents the situation:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/WCZL7RvHFy1ndQdYXdQfLqhe"/></p>
+
+<p>We can also say that this recipe uses &#x201C;4 eggs per cup of milk&#x201D; because the word <strong>per&#xA0;</strong>means &#x201C;for each.&#x201D;</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244607.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244607.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "name": "How Much for One?",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:a2db9757-33ce-5535-b0a2-11461a63663d",
+      "name": "Number Talk: Remainders in Division",
+      "alternateName": "6.2.8.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:cbe89b6c-c306-54b4-900f-fd337d976536",
+      "name": "Grocery Shopping",
+      "alternateName": "6.2.8.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:c29fe0e8-d33c-50a5-9e54-1065ece74c90",
+      "name": "More Shopping",
+      "alternateName": "6.2.8.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:142247a7-0bb6-577e-bdc4-ae42d8bfbc74",
+      "name": "I can choose and create diagrams to help me reason about prices.",
+      "alternateName": "I can choose and create diagrams to help me reason about prices."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:a8237f0c-16bd-5968-95ea-c6c73d6a8a35",
+      "name": "I can explain what the phrase &#x201C;at this rate&#x201D; means, using prices as an example.",
+      "alternateName": "I can explain what the phrase &#x201C;at this rate&#x201D; means, using prices as an example."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:301cf531-b3e5-5939-97cf-8591e13e0a5c",
+      "name": "If I know the price of multiple things, I can find the price per thing.",
+      "alternateName": "If I know the price of multiple things, I can find the price per thing."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244607.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244607.ocx.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+  "identifier": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+  "name": "How Much for One?",
+  "alternateName": "6.2.8",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15521",
+  "dateCreated": "2019-05-20 07:43:19 UTC",
+  "dateModified": "2021-07-22 14:08:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">How Much for One?</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s use ratios to describe how much things cost.</p>
+</div>
+    <div class="im_learning_targets">I can choose and create diagrams to help me reason about prices.
+I can explain what the phrase &#x201C;at this rate&#x201D; means, using prices as an example.
+If I know the price of multiple things, I can find the price per thing.</div>
+    <div class="im_glossary_entries">unit price: <p>The unit price is the cost for 1 item or for 1 unit of measure. For example, if 10 feet of chain link fencing cost \$150, then the unit price is <span><annotation description="\(150 \div 10\)"/></span>, or \$15 per foot.</p>
+</div>
+    <div class="im_student_lesson_summary"><p>The <strong>unit price</strong> is the price of 1 thing&#x2014;for example, the price of 1 ticket, 1 slice of pizza, or 1 kilogram of peaches.</p>
+
+<p>If 4 movie tickets cost \$28, then the unit price would be the cost <em>per</em> ticket. We can create a double number line to find the unit price.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/GD6oCkfXEQxoXmgEqUVTgtxk"/></p>
+
+<p>This double number line shows that the cost for 1 ticket is \$7. We can also find the unit price by dividing, <span><annotation description="\(28 \div 4 = 7\)"/></span>, or by multiplying, <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>28</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mfrac>
+    <mn>1</mn>
+    <mn>4</mn>
+  </mfrac>
+  <mo>=</mo>
+  <mn>7</mn>
+</math><annotation description="\(28 \boldcdot \frac14 = 7\)"/></span>.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244632.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244632.ocx.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+  "identifier": "im:fc11f54e-2159-5b06-b294-52faea278688",
+  "name": "Constant Speed",
+  "alternateName": "6.2.9",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15522",
+  "dateCreated": "2019-05-20 07:43:20 UTC",
+  "dateModified": "2021-07-26 15:28:04 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Constant Speed</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s use ratios to work with how fast things move.</p>
+</div>
+    <div class="im_learning_targets">I can choose and create diagrams to help me reason about constant speed.
+If I know that an object is moving at a constant speed, and I know two of these things: the distance it travels, the amount of time it takes, and its speed, I can find the other thing.</div>
+    <div class="im_glossary_entries">meters per second: <p>Meters per second is a unit for measuring speed. It tells how many meters an object goes in one second.</p>
+
+<p>For example, a person walking 3 meters per second is going faster than another person walking 2 meters per second.</p>
+</div>
+    <div class="im_student_lesson_summary"><p>Suppose a train traveled 100 meters in 5 seconds at a constant speed. To find its speed in <strong>meters per second,</strong> we can create a double number line:</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/AvwRtdNaQ5aPkW8AM4cmMTeX"/></p>
+
+<p>The double number line shows that the train&#x2019;s speed was 20 meters per second. We can also find the speed by dividing: <span><annotation description="\(100 \div 5 = 20\)"/></span>.</p>
+
+<p>Once we know the speed in meters per second, many questions about the situation become simpler to answer because we can multiply the amount of time an object travels by the speed to get the distance. For example, at this rate, how far would the train go in 30 seconds? Since <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>20</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>30</mn>
+  <mo>=</mo>
+  <mn>600</mn>
+</math><annotation description="\(20 \boldcdot 30 = 600\)"/></span>, the train would go 600 meters in 30 seconds.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244632.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244632.ocx.html
@@ -35,8 +35,41 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "name": "Constant Speed",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:89e59cd7-8ac5-581f-9d28-cffbc6418de6",
+      "name": "Number Talk: Dividing by Powers of 10",
+      "alternateName": "6.2.9.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:9cda7f06-db28-53ec-af1c-69a3fbbd3c2f",
+      "name": "Moving 10 Meters",
+      "alternateName": "6.2.9.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:7dbed290-832e-5f41-aa7c-83c7b6dee93b",
+      "name": "Moving for 10 Seconds",
+      "alternateName": "6.2.9.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:25c5b743-6fce-5057-8f75-7521bf83f48d",
+      "name": "I can choose and create diagrams to help me reason about constant speed.",
+      "alternateName": "I can choose and create diagrams to help me reason about constant speed."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:48d44a46-268a-526a-b141-893768d82fd6",
+      "name": "If I know that an object is moving at a constant speed, and I know two of these things: the distance it travels, the amount of time it takes, and its speed, I can find the other thing.",
+      "alternateName": "If I know that an object is moving at a constant speed, and I know two of these things: the distance it travels, the amount of time it takes, and its speed, I can find the other thing."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244660.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244660.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "name": "Comparing Situations by Examining Ratios",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:a047f873-6a24-528a-af44-f4d08e8edf83",
+      "name": "Treadmills",
+      "alternateName": "6.2.10.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:2e31ffc9-c5e2-50d4-957a-b133c5bca97b",
+      "name": "Concert Tickets",
+      "alternateName": "6.2.10.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:6456a693-daf9-55a2-874c-e27795b6ff3d",
+      "name": "Sparkling Orange Juice",
+      "alternateName": "6.2.10.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:5876c45f-a1c6-5ea3-8f61-c344e8c74bd4",
+      "name": "I can decide whether or not two situations are happening at the same rate.",
+      "alternateName": "I can decide whether or not two situations are happening at the same rate."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:e72ef012-245a-56ae-affb-d086a1369bd2",
+      "name": "I can explain what it means when two situations happen at the same rate.",
+      "alternateName": "I can explain what it means when two situations happen at the same rate."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:32bae37c-7ade-52b6-81f4-c5ad984fcac7",
+      "name": "I know some examples of situations where things can happen at the same rate.",
+      "alternateName": "I know some examples of situations where things can happen at the same rate."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244660.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244660.ocx.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+  "identifier": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+  "name": "Comparing Situations by Examining Ratios",
+  "alternateName": "6.2.10",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15523",
+  "dateCreated": "2019-05-20 07:43:20 UTC",
+  "dateModified": "2021-07-22 14:07:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Comparing Situations by Examining Ratios</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s use ratios to compare situations.</p>
+</div>
+    <div class="im_learning_targets">I can decide whether or not two situations are happening at the same rate.
+I can explain what it means when two situations happen at the same rate.
+I know some examples of situations where things can happen at the same rate.</div>
+    <div class="im_glossary_entries">same rate: <p>The phrase &#x201C;same rate&#x201D; is used to describe two situations that have equivalent ratios.</p>
+
+<p>For example, a sink is filled with water at a rate of 2 gallons per minute. If a tub is also filled with water at a rate of 2 gallons per minute, then the sink and the tub are filled at the same rate.</p>
+</div>
+    <div class="im_student_lesson_summary"><p>Sometimes we want to know whether two situations are described by the <strong>same rate</strong>. To do that, we can write an equivalent ratio for one or both situations&#xA0;so that one part of their ratios has&#xA0;the same value.&#xA0;Then&#xA0;we can compare the other part of the ratios.</p>
+
+<p>For example, do these two paint mixtures make the same shade of orange?</p>
+
+<ul>
+	<li>Kiran mixes 9 teaspoons of red paint with 15 teaspoons of yellow paint.</li>
+	<li>Tyler mixes 7 teaspoons of red paint with 10 teaspoons of yellow paint.</li>
+</ul>
+
+<p>Here is a double number line that represents Kiran's paint mixture. The ratio <span><annotation description="\(9:15\)"/></span> is equivalent to the ratios <span><annotation description="\(3:5\)"/></span> and <span><annotation description="\(6:10\)"/></span>.</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/HkMi6eY4JJjCpNT3XHSR9sJZ"/></p>
+
+<p>For 10 teaspoons of yellow paint, Kiran would mix in 6 teaspoons of red paint. This is less red paint than&#xA0;Tyler mixes with 10 teaspoons of yellow paint. The ratios <span><annotation description="\(6:10\)"/></span> and <span><annotation description="\(7:10\)"/></span> are not equivalent, so these two paint mixtures would not be the same shade of orange.</p>
+
+<p>When we talk about two things happening at the same rate, we mean that the ratios of the quantities in the two situations are equivalent. There is also something specific about the situation that is the same.</p>
+
+<ul>
+	<li>If two ladybugs are moving at the same rate, then they are traveling at the <em>same constant speed</em>.</li>
+	<li>If two bags of apples are selling for the same rate, then they have the <em>same unit price</em>.</li>
+	<li>If we mix two kinds of juice at the same rate, then the mixtures have the <em>same taste</em>.</li>
+	<li>If we mix two colors of paint at the same rate, then the mixtures have the <em>same shade</em>.</li>
+</ul>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244686.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244686.ocx.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+  "identifier": "im:48023702-a22e-5289-b62c-32913dcfe253",
+  "name": "Representing Ratios with Tables",
+  "alternateName": "6.2.11",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15524",
+  "dateCreated": "2019-05-20 07:43:20 UTC",
+  "dateModified": "2021-07-22 14:07:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Representing Ratios with Tables</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s use tables to represent equivalent ratios.</p>
+</div>
+    <div class="im_learning_targets">If I am looking at a table of values, I know where the rows are and where the columns are.
+When I see a table representing a set of equivalent ratios, I can come up with numbers to make a new row.
+When I see a table representing a set of equivalent ratios, I can explain what the numbers mean. </div>
+    <div class="im_glossary_entries">table: <div>
+<div>
+<div>
+<p>A table organizes information into horizontal <em>rows</em> and vertical <em>columns</em>. The first row or column usually tells what the numbers represent.</p>
+
+<p>For example, here is a table showing the tail lengths of 3 different pets. This table has 4 rows and 2 columns.</p>
+</div>
+
+<div>
+<table border="1">
+	<thead>
+		<tr>
+			<th scope="row">pet</th>
+			<th scope="col">tail&#xA0;length (inches)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>dog</td>
+			<td>22</td>
+		</tr>
+		<tr>
+			<td>cat</td>
+			<td>12</td>
+		</tr>
+		<tr>
+			<td>mouse</td>
+			<td>2</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+    <div class="im_student_lesson_summary"><p>A <strong>table</strong> is a way to organize information. Each horizontal set of entries is called a <em>row</em>, and each vertical set of entries is called a <em>column</em>. (The table shown has 2 columns and 5 rows.)&#xA0;A table can be used to represent a collection of equivalent ratios.</p>
+
+<p>Here is a double number line diagram and a table that both represent the&#xA0;situation:&#xA0;&#x201C;The price is \$2&#xA0;for every 3 mangos.&#x201D;</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/wzfPLctnTSRzi97K5DuFhQpV"/></p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/oQ6AF3VwxLzQdn1j3JW7M41b"/></p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244686.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244686.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+    "name": "Representing Ratios with Tables",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:1d9d8498-c9b2-50bf-a563-d0d329e27da1",
+      "name": "How Is It Growing?",
+      "alternateName": "6.2.11.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:989e142a-1831-5cda-bbd3-a2c9fc0d8d67",
+      "name": "A Huge Amount of Sparkling Orange Juice",
+      "alternateName": "6.2.11.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:6d8e2e83-8abc-58b7-ac7d-c70f0d198933",
+      "name": "Batches of Trail Mix",
+      "alternateName": "6.2.11.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:d4601bb7-1926-5f19-a06d-2061a7dbb0f5",
+      "name": "If I am looking at a table of values, I know where the rows are and where the columns are.",
+      "alternateName": "If I am looking at a table of values, I know where the rows are and where the columns are."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:b703ac25-4a76-5a5e-bb64-c1af1396cf81",
+      "name": "When I see a table representing a set of equivalent ratios, I can come up with numbers to make a new row.",
+      "alternateName": "When I see a table representing a set of equivalent ratios, I can come up with numbers to make a new row."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:29ed23a5-52bc-5fb0-9230-2db61b31b12b",
+      "name": "When I see a table representing a set of equivalent ratios, I can explain what the numbers mean. ",
+      "alternateName": "When I see a table representing a set of equivalent ratios, I can explain what the numbers mean. "
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244709.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244709.ocx.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+  "identifier": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+  "name": "Navigating a Table of Equivalent Ratios",
+  "alternateName": "6.2.12",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15525",
+  "dateCreated": "2019-05-20 07:43:20 UTC",
+  "dateModified": "2021-07-22 14:07:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Navigating a Table of Equivalent Ratios</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s use a table of equivalent ratios like a pro.</p>
+</div>
+    <div class="im_learning_targets">I can solve problems about situations happening at the same rate by using a table and finding a &#x201C;1&#x201D; row.
+I can use a table of equivalent ratios to solve problems about unit price.</div>
+    <div class="im_glossary_entries"/>
+    <div class="im_student_lesson_summary"><p>Finding a row containing a &#x201C;1&#x201D; is often a good way to work with tables of equivalent ratios. For example, the price for 4 lbs of granola is \$5. At that rate, what would be the price for 62 lbs of granola?</p>
+
+<p>Here are tables showing two different approaches to solving this&#xA0;problem.&#xA0;Both of these approaches are correct. However, one approach is more efficient.</p>
+
+<ul>
+	<li>
+	<p>Less efficient</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/LjnGdGe1JkMeJDzssXgNzb6r"/></p>
+	</li>
+	<li>
+	<p>More efficient</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/JAu1Ewq3xjSGGM16nno4UpGi"/></p>
+	</li>
+</ul>
+
+<p>Notice how the more efficient approach&#xA0;starts by finding the price for 1 lb of granola.</p>
+
+<p>Remember that dividing by a whole number is the same as multiplying by a unit fraction. In this&#xA0;example, we can divide by 4 or multiply by <span><annotation description="\(\frac14\)"/></span> to find the unit price.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244709.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244709.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+    "name": "Navigating a Table of Equivalent Ratios",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:49419b28-5297-5f1c-a83c-c106cbfa35b6",
+      "name": "Number Talk: Multiplying by a Unit Fraction",
+      "alternateName": "6.2.12.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:2990bc9d-7024-515e-8dda-40790f4cc5d3",
+      "name": "Comparing Taco Prices",
+      "alternateName": "6.2.12.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:8abd27e9-ac06-5adc-a6ce-7b09aceb39e4",
+      "name": "Hourly Wages",
+      "alternateName": "6.2.12.3"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:d0509b9d-5dc2-54bd-affb-b315b40112d6",
+      "name": "Zeno&#x2019;s Memory Card",
+      "alternateName": "6.2.12.4"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:2f48b1e4-41e4-56ec-90c2-b7ca1a31c33b",
+      "name": "I can solve problems about situations happening at the same rate by using a table and finding a &#x201C;1&#x201D; row.",
+      "alternateName": "I can solve problems about situations happening at the same rate by using a table and finding a &#x201C;1&#x201D; row."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:8bbc0027-e05a-54dd-8ebd-5887ab2f2b6c",
+      "name": "I can use a table of equivalent ratios to solve problems about unit price.",
+      "alternateName": "I can use a table of equivalent ratios to solve problems about unit price."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244740.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244740.ocx.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+  "identifier": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+  "name": "Tables and Double Number Line Diagrams",
+  "alternateName": "6.2.13",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15526",
+  "dateCreated": "2019-05-20 07:43:21 UTC",
+  "dateModified": "2021-07-26 15:30:55 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Tables and Double Number Line Diagrams</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s contrast double number lines and tables.</p>
+</div>
+    <div class="im_learning_targets">I can create a table that represents a set of equivalent ratios.
+I can explain why sometimes a table is easier to use than a double number line to solve problems involving equivalent ratios.
+I include column labels when I create a table, so that the meaning of the numbers is clear.</div>
+    <div class="im_glossary_entries"/>
+    <div class="im_student_lesson_summary"><p>On a double number line diagram, we put labels in front of each line to tell what the numbers represent. On a table, we put labels at the top of each column to tell what the numbers represent.</p>
+
+<p>Here are two different ways we can represent the situation: &#x201C;A snail is moving at a constant speed down a sidewalk, traveling&#xA0;6 centimeters per minute.&#x201D;</p>
+
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/WTeXy1EtCZ4SMNa2r4Fu1VBa"/></p>
+
+<p>Both double number lines and tables can help us use multiplication to make equivalent ratios, but there is an important difference between the two representations.</p>
+
+<p>On a double number line, the numbers on each line are listed in order. With a table, you can write the ratios in any order. For this reason, sometimes a table is easier to use&#xA0;to solve a problem.</p>
+
+<p>For example, what if we wanted to know how far the snail travels in 10 minutes? Notice that 60 centimeters in 10 minutes is shown on the table, but there is not enough room for this information on the double number line.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244740.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244740.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+    "name": "Tables and Double Number Line Diagrams",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:df3cb07e-1b84-596c-96a2-1b0c63ca812c",
+      "name": "Number Talk: Constant Dividend",
+      "alternateName": "6.2.13.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:f3e99fe4-4c1f-51f0-844c-cbd7df168f3c",
+      "name": "Moving 3,000 Meters",
+      "alternateName": "6.2.13.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:3aae636e-e597-5d55-9bd1-6c4883cd4f09",
+      "name": "The International Space Station",
+      "alternateName": "6.2.13.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:36219917-fdf3-500e-89c4-d095e32e9f77",
+      "name": "I can create a table that represents a set of equivalent ratios.",
+      "alternateName": "I can create a table that represents a set of equivalent ratios."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:6d3be8d2-7f50-5a62-ab78-685656020ad1",
+      "name": "I can explain why sometimes a table is easier to use than a double number line to solve problems involving equivalent ratios.",
+      "alternateName": "I can explain why sometimes a table is easier to use than a double number line to solve problems involving equivalent ratios."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:df65fd83-9dee-54e7-8887-c81d4fcf1113",
+      "name": "I include column labels when I create a table, so that the meaning of the numbers is clear.",
+      "alternateName": "I include column labels when I create a table, so that the meaning of the numbers is clear."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244764.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244764.ocx.html
@@ -35,8 +35,41 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+    "name": "Solving Equivalent Ratio Problems",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:0af6f728-bbd1-5525-ae39-a10f1e53c3ad",
+      "name": "What Do You Want to Know?",
+      "alternateName": "6.2.14.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:3366cf1d-3330-5652-92ae-f909526bfd86",
+      "name": "Info Gap: Hot Chocolate and Potatoes",
+      "alternateName": "6.2.14.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:26ac37ff-b61f-5af7-aa02-3ea0f096e913",
+      "name": "Comparing Reading Rates",
+      "alternateName": "6.2.14.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:fb6f0824-ef31-52e2-9bdc-17782903de5c",
+      "name": "I can decide what information I need to know to be able to solve problems about situations happening at the same rate.",
+      "alternateName": "I can decide what information I need to know to be able to solve problems about situations happening at the same rate."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:6fa30726-12c8-5d79-a3f5-2ba8ed9a744f",
+      "name": "I can explain my reasoning using diagrams that I choose.",
+      "alternateName": "I can explain my reasoning using diagrams that I choose."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244764.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244764.ocx.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+  "identifier": "im:69f54880-625b-5f01-8d97-21862a906521",
+  "name": "Solving Equivalent Ratio Problems",
+  "alternateName": "6.2.14",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15527",
+  "dateCreated": "2019-05-20 07:43:21 UTC",
+  "dateModified": "2021-07-26 15:32:57 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Solving Equivalent Ratio Problems</div>
+    <div class="im_student_facing_learning_goals"><p>Let's practice getting information from our partner.</p>
+</div>
+    <div class="im_learning_targets">I can decide what information I need to know to be able to solve problems about situations happening at the same rate.
+I can explain my reasoning using diagrams that I choose.</div>
+    <div class="im_glossary_entries"/>
+    <div class="im_student_lesson_summary"><p>To solve problems about something happening at the same rate, we often&#xA0;need:</p>
+
+<ul>
+	<li>
+	<p>Two pieces of information that allow us to write&#xA0;a ratio that describes the situation.</p>
+	</li>
+	<li>
+	<p>A third piece of information that gives us one&#xA0;number of an equivalent ratio. Solving the problem often involves finding&#xA0;the other number in the equivalent ratio.</p>
+	</li>
+</ul>
+
+<p>Suppose we are making a large batch of fizzy juice and the recipe says, &#x201C;Mix 5 cups of cranberry juice with 2 cups of soda water.&#x201D; We know that the ratio of cranberry juice to soda water is <span><annotation description="\(5:2\)"/></span>, and&#xA0;that we need 2.5 cups of cranberry juice per cup of soda water.</p>
+
+<div>
+<div>
+<div>
+<p>We still need to know something about the size of the large batch. If we use 16 cups of soda water, what number goes with 16 to make a ratio that is equivalent to <span><annotation description="\(5:2\)"/></span>?</p>
+
+<p>To make this large batch taste the same as the original recipe, we would need to use&#xA0;40 cups of cranberry juice.</p>
+</div>
+
+<div>
+<table border="1" style="width:210px">
+	<thead>
+		<tr>
+			<th scope="col">cranberry juice&#xA0;(cups)</th>
+			<th scope="col">soda&#xA0;water (cups)</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>5</td>
+			<td>2</td>
+		</tr>
+		<tr>
+			<td>2.5</td>
+			<td>1</td>
+		</tr>
+		<tr>
+			<td>40</td>
+			<td>16</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244785.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244785.ocx.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+  "identifier": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+  "name": "Part-Part-Whole Ratios",
+  "alternateName": "6.2.15",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:13b9e821-9a4c-5948-80fd-6b079ec22658",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15528",
+  "dateCreated": "2019-05-20 07:43:21 UTC",
+  "dateModified": "2021-07-22 14:07:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Part-Part-Whole Ratios</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s look at situations where you can add the quantities in a ratio together.</p>
+</div>
+    <div class="im_learning_targets">I can create tape diagrams to help me reason about problems involving a ratio and a total amount.
+I can solve problems when I know a ratio and a total amount. </div>
+    <div class="im_glossary_entries">tape diagram: <p>A tape diagram is a group of rectangles put together to represent a relationship between quantities.</p>
+
+<div>
+<div>
+<div>
+<p>For example, this tape diagram shows a ratio of 30 gallons of yellow paint to 50 gallons of blue paint.</p>
+</div>
+
+<div><img src="https://staging-cms-assets.illustrativemathematics.org/8xkbekx85syy1wfflrky2ol3y1vt"/></div>
+</div>
+</div>
+
+<p>If each rectangle were labeled 5, instead of 10, then the same picture could represent the equivalent ratio of 15 gallons of yellow paint to 25 gallons of blue paint.</p>
+</div>
+    <div class="im_student_lesson_summary"><p>A <strong>tape diagram</strong> is another way to&#xA0;represent a ratio. All the parts of the diagram that are the same size have the same value.</p>
+
+<p>For example, this tape diagram represents the ratio of ducks to swans in a pond, which is <span><annotation description="\(4:5\)"/></span>.</p>
+
+<div>
+<div>
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/7DnGZ479V6wfWgsrfZzduR4W"/></p>
+</div>
+
+<div>
+<p>The first tape represents the number of ducks. It has 4 parts.</p>
+
+<p>The second tape represents the number of swans. It has 5 parts.</p>
+
+<p>There are&#xA0;9 parts in all, because <span><annotation description="\(4+5=9\)"/></span>.</p>
+</div>
+</div>
+</div>
+
+<p>Suppose we know there&#xA0;are 18 of these birds in the pond, and we want to know how many are ducks.</p>
+
+<div>
+<div>
+<div>
+<p><img src="https://staging-cms-assets.illustrativemathematics.org/GPYou7W9Tczv53MfEsothnZe"/></p>
+</div>
+
+<div>
+<p>The 9 equal parts on the diagram&#xA0;need to represent 18 birds in all. This means that each part of the tape diagram represents 2 birds, because <span><annotation description="\(18\div9 = 2\)"/></span>.</p>
+</div>
+</div>
+</div>
+
+<p>There are 4 parts of the tape representing ducks, and <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>4</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>2</mn>
+  <mo>=</mo>
+  <mn>8</mn>
+</math><annotation description="\(4 \boldcdot 2=8\)"/></span>, so there are 8 ducks in the pond.</p>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244785.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244785.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:13b9e821-9a4c-5948-80fd-6b079ec22658",
+    "name": "Part-Part-Whole Ratios",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:44078494-5d7c-5b2a-ae72-f4a2b67b1f5a",
+      "name": "True or False: Multiplying by a Unit Fraction",
+      "alternateName": "6.2.15.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:7940898a-db1e-5a3e-b99e-9d0680e7c942",
+      "name": "Cubes of Paint",
+      "alternateName": "6.2.15.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:575c8bf4-e11e-5fbd-9050-1be4ad8bff0f",
+      "name": "Sneakers, Chicken, and Fruit Juice",
+      "alternateName": "6.2.15.3"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:096cb7b7-01ba-53af-8abf-f0d97f88d70b",
+      "name": "Invent Your Own Ratio Problem",
+      "alternateName": "6.2.15.4"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:f95f6976-7b3d-5475-a83d-e1642105b3a5",
+      "name": "I can create tape diagrams to help me reason about problems involving a ratio and a total amount.",
+      "alternateName": "I can create tape diagrams to help me reason about problems involving a ratio and a total amount."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:32a166d9-39aa-5992-bbd8-d55389e67fd6",
+      "name": "I can solve problems when I know a ratio and a total amount. ",
+      "alternateName": "I can solve problems when I know a ratio and a total amount. "
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244809.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244809.ocx.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+  "identifier": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+  "name": "Solving More Ratio Problems",
+  "alternateName": "6.2.16",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:13b9e821-9a4c-5948-80fd-6b079ec22658",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15529",
+  "dateCreated": "2019-05-20 07:43:21 UTC",
+  "dateModified": "2021-07-26 15:39:38 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">Solving More Ratio Problems</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s compare all our strategies for solving ratio problems.</p>
+</div>
+    <div class="im_learning_targets">I can choose and create diagrams to help think through my solution. 
+I can solve all kinds of problems about equivalent ratios. 
+I can use diagrams to help someone else understand why my solution makes sense.</div>
+    <div class="im_glossary_entries"/>
+    <div class="im_student_lesson_summary"><p>When solving a problem involving equivalent ratios, it is often helpful to use a diagram. Any diagram is fine&#xA0;as long as it correctly shows the mathematics and you can explain it.</p>
+
+<p>Let&#x2019;s compare three different ways to solve the same problem: The ratio of adults to kids in a school is <span><annotation description="\(2:7\)"/></span>. If there is a total of 180 people, how many of them are adults?</p>
+
+<ul>
+	<li>
+	<p><em>Tape diagrams</em> are especially useful for this type of problem because both parts of the ratio have the same units (&#x201C;number of people")&#xA0;and we can see the total number of parts.</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/YwYqZQogvKDikjyZF565Wx5r"/></p>
+
+	<p>This tape diagram has 9 equal parts, and they need&#xA0;to represent 180 people total. That means each part represents <span><annotation description="\(180 \div 9\)"/></span>, or 20 people.</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/8pKFqw8V3bPkiDSysMrk3LGY"/></p>
+
+	<p>Two parts of the tape diagram represent adults. There are 40 adults in the school because <span><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mn>2</mn>
+  <mrow>
+    <mpadded height="-.1em" depth="+.1em" voffset="-.1em">
+      <mstyle mathsize="1.44em">
+        <mo>&#x22C5;<!-- ⋅ --></mo>
+      </mstyle>
+    </mpadded>
+  </mrow>
+  <mn>20</mn>
+  <mo>=</mo>
+  <mn>40</mn>
+</math><annotation description="\(2\boldcdot 20 = 40\)"/></span>.</p>
+	</li>
+	<li>
+	<p><em>Double or triple number lines</em> are useful when we want&#xA0;to see how far apart the numbers are from one another. They are harder to use with very big or very small numbers, but they could support our reasoning.</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/15aHrS2GbR5FrYKG1iDV6zFm"/></p>
+	<presentation-tag src="/presentation_tags/2.tag"/>
+</li>
+	<li>
+	<p><em>Tables</em> are&#xA0;especially useful when the problem has very large or very small numbers.</p>
+
+	<p><img src="https://staging-cms-assets.illustrativemathematics.org/eTSR3nCUarcYA3YPVf1vrHbL"/></p>
+
+	<p>We ask ourselves, &#x201C;9 times what is 180?&#x201D; The answer is 20. Next, we multiply 2 by 20 to get the total number of adults in the school.</p>
+	</li>
+</ul>
+
+<p>Another reason to make diagrams is to communicate our thinking to others. Here are some good habits when making diagrams:</p>
+
+<ul>
+	<li>Label each part of the diagram with what it represents.</li>
+	<li>Label important amounts.</li>
+	<li>Make sure you read what the question is asking and answer it.</li>
+	<li>Make sure you make the answer easy to find.</li>
+	<li>Include units in your answer. For example, write &#x201C;4 cups&#x201D; instead of just &#x201C;4.&#x201D;</li>
+	<li>
+	<p>Double check that your ratio language is correct and matches your diagram.</p>
+	</li>
+</ul>
+</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/lesson-node-244809.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244809.ocx.html
@@ -35,8 +35,47 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:13b9e821-9a4c-5948-80fd-6b079ec22658",
+    "name": "Solving More Ratio Problems",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:ae5c628d-366b-5f8b-8143-00e94e504ab6",
+      "name": "You Tell the Story",
+      "alternateName": "6.2.16.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:75d6f6d1-0c7b-5ba3-a197-d3fb787fed0c",
+      "name": "A Trip to the Aquarium",
+      "alternateName": "6.2.16.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:1973ccaa-d922-5f73-a113-2ed43f91ec0a",
+      "name": "Salad Dressing and Moving Boxes",
+      "alternateName": "6.2.16.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:048bd8ca-1126-5aea-8564-c5f5ee4b1f73",
+      "name": "I can choose and create diagrams to help think through my solution. ",
+      "alternateName": "I can choose and create diagrams to help think through my solution. "
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:a25a7b50-f3a5-5420-ba9d-4c8ffcf51f77",
+      "name": "I can solve all kinds of problems about equivalent ratios. ",
+      "alternateName": "I can solve all kinds of problems about equivalent ratios. "
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:7bf88bbc-1ef4-5416-a331-733be9864f5c",
+      "name": "I can use diagrams to help someone else understand why my solution makes sense.",
+      "alternateName": "I can use diagrams to help someone else understand why my solution makes sense."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244833.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244833.ocx.html
@@ -35,8 +35,41 @@
   "isPartOf": {
     "@type": "oer:Section",
     "@id": "im:c2939826-ccbe-52dd-aea6-ed30ec624f85",
+    "name": "A Fermi Problem",
     "courseCode": "6.2."
   },
+  "hasPart": [
+    {
+      "@type": "oer:Activity",
+      "@id": "im:3c930b8d-761b-5cc0-bb97-63bee8bd4939",
+      "name": "Fix It!",
+      "alternateName": "6.2.17.1"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:18d72e97-6e56-5b5b-876d-e08579180af5",
+      "name": "Who Was Fermi?",
+      "alternateName": "6.2.17.2"
+    },
+    {
+      "@type": "oer:Activity",
+      "@id": "im:5c7de132-c80f-5855-a8b4-1960d23863c3",
+      "name": "Researching Your Own Fermi Problem",
+      "alternateName": "6.2.17.3"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:e9090ac4-9e1d-5dfc-9b21-9fc16c26eff5",
+      "name": "I can apply what I have learned about ratios and rates to solve a more complicated problem.",
+      "alternateName": "I can apply what I have learned about ratios and rates to solve a more complicated problem."
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:8117ec2f-6cc2-55ad-92c6-18ad44c09727",
+      "name": "I can decide what information I need to know to be able to solve a real-world problem about ratios and rates.",
+      "alternateName": "I can decide what information I need to know to be able to solve a real-world problem about ratios and rates."
+    }
+  ],
   "learningResourceType": [
     "Lesson"
   ],

--- a/build/cms_im-PR1142/lesson-node-244833.ocx.html
+++ b/build/cms_im-PR1142/lesson-node-244833.ocx.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Lesson",
+  "@id": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+  "identifier": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+  "name": "A Fermi Problem",
+  "alternateName": "6.2.17",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Section",
+    "@id": "im:c2939826-ccbe-52dd-aea6-ed30ec624f85",
+    "courseCode": "6.2."
+  },
+  "learningResourceType": [
+    "Lesson"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Lesson",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/lessons/15530",
+  "dateCreated": "2019-05-20 07:43:21 UTC",
+  "dateModified": "2021-07-26 15:41:35 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Lesson.name">A Fermi Problem</div>
+    <div class="im_student_facing_learning_goals"><p>Let&#x2019;s solve a Fermi problem.</p>
+</div>
+    <div class="im_learning_targets">I can apply what I have learned about ratios and rates to solve a more complicated problem.
+I can decide what information I need to know to be able to solve a real-world problem about ratios and rates.</div>
+    <div class="im_glossary_entries"/>
+    <div class="im_student_lesson_summary"/>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244429.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244429.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:eac7e5e3-083e-52ee-b9de-3394ab5e800c",
+  "identifier": "im:eac7e5e3-083e-52ee-b9de-3394ab5e800c",
+  "name": "Aligned PP Set for Introducing Ratios and Ratio Language",
+  "alternateName": "6.2.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "courseCode": "6.2.1"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25531",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:11 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Introducing Ratios and Ratio Language</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244429.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244429.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "name": "Aligned PP Set for Introducing Ratios and Ratio Language",
     "courseCode": "6.2.1"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244446.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244446.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:1b678872-ea47-516d-a8a9-6b30b7a415fe",
+  "identifier": "im:1b678872-ea47-516d-a8a9-6b30b7a415fe",
+  "name": "Cumulative PP Set for Introducing Ratios and Ratio Language",
+  "alternateName": "6.2.1",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "courseCode": "6.2.1"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25532",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:23:26 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Introducing Ratios and Ratio Language</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244446.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244446.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f1ca85f1-64e9-5053-ba8b-eb2ef3882d1a",
+    "name": "Cumulative PP Set for Introducing Ratios and Ratio Language",
     "courseCode": "6.2.1"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244459.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244459.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:5c2d41b2-2b25-5b71-b956-c7e7f4ac4d97",
+  "identifier": "im:5c2d41b2-2b25-5b71-b956-c7e7f4ac4d97",
+  "name": "Aligned PP Set for Representing Ratios with Diagrams",
+  "alternateName": "6.2.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "courseCode": "6.2.2"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25533",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:11 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Representing Ratios with Diagrams</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244459.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244459.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "name": "Aligned PP Set for Representing Ratios with Diagrams",
     "courseCode": "6.2.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244469.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244469.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "name": "Cumulative PP Set for Representing Ratios with Diagrams",
     "courseCode": "6.2.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244469.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244469.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:0b13c509-e967-5554-acaa-0578313006f1",
+  "identifier": "im:0b13c509-e967-5554-acaa-0578313006f1",
+  "name": "Cumulative PP Set for Representing Ratios with Diagrams",
+  "alternateName": "6.2.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:0bff100f-6fed-5675-a29d-0b6d4b1d44a1",
+    "courseCode": "6.2.2"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25534",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:11 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Representing Ratios with Diagrams</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244482.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244482.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "name": "Aligned PP Set for Recipes",
     "courseCode": "6.2.3"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244482.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244482.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:b8163605-8bda-5d96-b1c6-e6cbe328c639",
+  "identifier": "im:b8163605-8bda-5d96-b1c6-e6cbe328c639",
+  "name": "Aligned PP Set for Recipes",
+  "alternateName": "6.2.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "courseCode": "6.2.3"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25535",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:12 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Recipes</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244497.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244497.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "name": "Cumulative PP Set for Recipes",
     "courseCode": "6.2.3"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244497.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244497.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:8d88741f-8bd3-509f-9979-4897fa94d525",
+  "identifier": "im:8d88741f-8bd3-509f-9979-4897fa94d525",
+  "name": "Cumulative PP Set for Recipes",
+  "alternateName": "6.2.3",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8e9c064f-9191-58f2-be1f-a2533c7a94ef",
+    "courseCode": "6.2.3"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25536",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:12 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Recipes</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244511.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244511.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:0afb8e11-f197-5e0f-8b91-eafb23bd2782",
+  "identifier": "im:0afb8e11-f197-5e0f-8b91-eafb23bd2782",
+  "name": "Aligned PP Set for Color Mixtures",
+  "alternateName": "6.2.4",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "courseCode": "6.2.4"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25537",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:12 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Color Mixtures</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244511.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244511.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "name": "Aligned PP Set for Color Mixtures",
     "courseCode": "6.2.4"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244526.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244526.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "name": "Cumulative PP Set for Color Mixtures",
     "courseCode": "6.2.4"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244526.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244526.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:81dda5ac-0b9a-5538-b0c0-99d2e9693d13",
+  "identifier": "im:81dda5ac-0b9a-5538-b0c0-99d2e9693d13",
+  "name": "Cumulative PP Set for Color Mixtures",
+  "alternateName": "6.2.4",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:5756d06a-3a6d-5311-a6fc-b5aff99a7824",
+    "courseCode": "6.2.4"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25538",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:23:27 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Color Mixtures</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244539.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244539.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "name": "Aligned PP Set for Defining Equivalent Ratios",
     "courseCode": "6.2.5"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244539.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244539.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:285587a3-a92b-5723-857b-b33fe626ddec",
+  "identifier": "im:285587a3-a92b-5723-857b-b33fe626ddec",
+  "name": "Aligned PP Set for Defining Equivalent Ratios",
+  "alternateName": "6.2.5",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "courseCode": "6.2.5"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25539",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Defining Equivalent Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244553.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244553.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "name": "Cumulative PP Set for Defining Equivalent Ratios",
     "courseCode": "6.2.5"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244553.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244553.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:b20d6119-9eda-5953-b3da-9151ade48c15",
+  "identifier": "im:b20d6119-9eda-5953-b3da-9151ade48c15",
+  "name": "Cumulative PP Set for Defining Equivalent Ratios",
+  "alternateName": "6.2.5",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:769ba4e8-ee29-5c96-ac91-b5766efb12bf",
+    "courseCode": "6.2.5"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25540",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Defining Equivalent Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244566.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244566.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "name": "Aligned PP Set for Introducing Double Number Line Diagrams",
     "courseCode": "6.2.6"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244566.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244566.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:3d1c7718-646e-5a19-a1d0-39d08fe33cb7",
+  "identifier": "im:3d1c7718-646e-5a19-a1d0-39d08fe33cb7",
+  "name": "Aligned PP Set for Introducing Double Number Line Diagrams",
+  "alternateName": "6.2.6",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "courseCode": "6.2.6"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25541",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Introducing Double Number Line Diagrams</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244575.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244575.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "name": "Cumulative PP Holding Section",
     "courseCode": "6.2.6"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244575.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244575.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:a97b7e35-de6a-50cd-9cc0-62e6e39cb9c5",
+  "identifier": "im:a97b7e35-de6a-50cd-9cc0-62e6e39cb9c5",
+  "name": "Cumulative PP Holding Section",
+  "alternateName": "6.2.6",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:90f83c9f-0b18-5a2e-84d9-651d0312363f",
+    "courseCode": "6.2.6"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25542",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:13 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Holding Section</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244588.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244588.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "name": "Aligned PP Set for Creating Double Number Line Diagrams",
     "courseCode": "6.2.7"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244588.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244588.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:0298bd00-ebcc-5df8-8244-df85fb80dc39",
+  "identifier": "im:0298bd00-ebcc-5df8-8244-df85fb80dc39",
+  "name": "Aligned PP Set for Creating Double Number Line Diagrams",
+  "alternateName": "6.2.7",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "courseCode": "6.2.7"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25543",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:14 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Creating Double Number Line Diagrams</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244598.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244598.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "name": "Cumulative PP Set for Creating Double Number Line Diagrams",
     "courseCode": "6.2.7"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244598.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244598.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:4e9ebd09-8698-5063-bf89-d6fd2fb1a0ef",
+  "identifier": "im:4e9ebd09-8698-5063-bf89-d6fd2fb1a0ef",
+  "name": "Cumulative PP Set for Creating Double Number Line Diagrams",
+  "alternateName": "6.2.7",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:e772f16e-524f-5792-a7ea-4b0d62d1adf5",
+    "courseCode": "6.2.7"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25544",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:14 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Creating Double Number Line Diagrams</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244612.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244612.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:fd37ed32-f0c3-593d-91eb-21962e9be5d3",
+  "identifier": "im:fd37ed32-f0c3-593d-91eb-21962e9be5d3",
+  "name": "Aligned PP Set for How Much for One?",
+  "alternateName": "6.2.8",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "courseCode": "6.2.8"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25545",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:14 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for How Much for One?</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244612.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244612.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "name": "Aligned PP Set for How Much for One?",
     "courseCode": "6.2.8"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244625.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244625.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "name": "Cumulative PP Set for How Much for One?",
     "courseCode": "6.2.8"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244625.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244625.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:dbb4eff4-087d-546f-8589-c792bafc56e9",
+  "identifier": "im:dbb4eff4-087d-546f-8589-c792bafc56e9",
+  "name": "Cumulative PP Set for How Much for One?",
+  "alternateName": "6.2.8",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:84a3f142-7edf-5eca-aa46-87b529bdf052",
+    "courseCode": "6.2.8"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25546",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:23:30 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for How Much for One?</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244637.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244637.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "name": "Aligned PP Set for Constant Speed",
     "courseCode": "6.2.9"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244637.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244637.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:652663e2-17b8-5b0c-8490-15fd589e4a81",
+  "identifier": "im:652663e2-17b8-5b0c-8490-15fd589e4a81",
+  "name": "Aligned PP Set for Constant Speed",
+  "alternateName": "6.2.9",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "courseCode": "6.2.9"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25547",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Constant Speed</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244651.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244651.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "name": "Cumulative PP Set for Constant Speed",
     "courseCode": "6.2.9"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244651.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244651.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:b3b1c9e2-14a1-507b-b793-8d5d468fa642",
+  "identifier": "im:b3b1c9e2-14a1-507b-b793-8d5d468fa642",
+  "name": "Cumulative PP Set for Constant Speed",
+  "alternateName": "6.2.9",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:fc11f54e-2159-5b06-b294-52faea278688",
+    "courseCode": "6.2.9"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25548",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Constant Speed</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244665.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244665.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:d5e60229-ebf7-55ae-857e-e0e477f64700",
+  "identifier": "im:d5e60229-ebf7-55ae-857e-e0e477f64700",
+  "name": "Aligned PP Set for Comparing Situations by Examining Ratios",
+  "alternateName": "6.2.10",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "courseCode": "6.2.10"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25549",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Comparing Situations by Examining Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244665.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244665.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "name": "Aligned PP Set for Comparing Situations by Examining Ratios",
     "courseCode": "6.2.10"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244677.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244677.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:06ab3e63-b8f3-5b16-9368-82eb05ca62d5",
+  "identifier": "im:06ab3e63-b8f3-5b16-9368-82eb05ca62d5",
+  "name": "Cumulative PP Set for Comparing Situations by Examining Ratios",
+  "alternateName": "6.2.10",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "courseCode": "6.2.10"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25550",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:15 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Comparing Situations by Examining Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244677.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244677.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:f5136e42-68b5-5c8e-b0c2-4e8a0e3ae0f8",
+    "name": "Cumulative PP Set for Comparing Situations by Examining Ratios",
     "courseCode": "6.2.10"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244691.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244691.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "name": "Aligned PP Set for Representing Ratios with Tables",
     "courseCode": "6.2.11"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244691.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244691.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:ff69d8ea-50fa-5603-a51b-7d1d7a0dc96f",
+  "identifier": "im:ff69d8ea-50fa-5603-a51b-7d1d7a0dc96f",
+  "name": "Aligned PP Set for Representing Ratios with Tables",
+  "alternateName": "6.2.11",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "courseCode": "6.2.11"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25551",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:16 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Representing Ratios with Tables</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244702.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244702.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "name": "Cumulative PP Set for Representing Ratios with Tables",
     "courseCode": "6.2.11"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244702.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244702.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:6f59f697-e428-5de4-9d68-da73094e68e0",
+  "identifier": "im:6f59f697-e428-5de4-9d68-da73094e68e0",
+  "name": "Cumulative PP Set for Representing Ratios with Tables",
+  "alternateName": "6.2.11",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:48023702-a22e-5289-b62c-32913dcfe253",
+    "courseCode": "6.2.11"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25552",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:16 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Representing Ratios with Tables</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244715.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244715.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:8e914bf9-df1d-5c3c-92a2-1593aa4bcaf8",
+  "identifier": "im:8e914bf9-df1d-5c3c-92a2-1593aa4bcaf8",
+  "name": "Aligned PP Set for Navigating a Table of Equivalent Ratios",
+  "alternateName": "6.2.12",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "courseCode": "6.2.12"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25553",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:16 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Navigating a Table of Equivalent Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244715.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244715.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "name": "Aligned PP Set for Navigating a Table of Equivalent Ratios",
     "courseCode": "6.2.12"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244732.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244732.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "name": "Cumulative PP Set for Navigating a Table of Equivalent Ratios",
     "courseCode": "6.2.12"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244732.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244732.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:b249aaf3-bd6c-512f-9b4a-0057cf2151e1",
+  "identifier": "im:b249aaf3-bd6c-512f-9b4a-0057cf2151e1",
+  "name": "Cumulative PP Set for Navigating a Table of Equivalent Ratios",
+  "alternateName": "6.2.12",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:1ccb26c8-e5d8-5a9c-99b1-14391feba7d8",
+    "courseCode": "6.2.12"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25554",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:17 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Navigating a Table of Equivalent Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244745.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244745.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "name": "Aligned PP Set for Tables and Double Number Line Diagrams",
     "courseCode": "6.2.13"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244745.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244745.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:a45ab28f-5a9d-5b07-a66c-e1ac42416a9d",
+  "identifier": "im:a45ab28f-5a9d-5b07-a66c-e1ac42416a9d",
+  "name": "Aligned PP Set for Tables and Double Number Line Diagrams",
+  "alternateName": "6.2.13",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "courseCode": "6.2.13"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25555",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:16 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Tables and Double Number Line Diagrams</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244757.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244757.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:68300aa3-a0fd-5bd0-882e-a4fbad437fd0",
+  "identifier": "im:68300aa3-a0fd-5bd0-882e-a4fbad437fd0",
+  "name": "Cumulative PP Set for Tables and Double Number Line Diagrams",
+  "alternateName": "6.2.13",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "courseCode": "6.2.13"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25556",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:23:34 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Tables and Double Number Line Diagrams</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244757.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244757.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:3b7ea7bc-a194-561a-94d6-013c379ad272",
+    "name": "Cumulative PP Set for Tables and Double Number Line Diagrams",
     "courseCode": "6.2.13"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244769.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244769.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "name": "Aligned PP Set for Solving Equivalent Ratio Problems",
     "courseCode": "6.2.14"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244769.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244769.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:4ec03e96-8235-575e-8c88-c6cff930bc92",
+  "identifier": "im:4ec03e96-8235-575e-8c88-c6cff930bc92",
+  "name": "Aligned PP Set for Solving Equivalent Ratio Problems",
+  "alternateName": "6.2.14",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "courseCode": "6.2.14"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25557",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:17 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Solving Equivalent Ratio Problems</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244777.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244777.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "name": "Cumulative PP Set for Solving Equivalent Ratio Problems",
     "courseCode": "6.2.14"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244777.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244777.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:1f4406be-bb4d-5bdd-ab77-5f2fad7bfc9b",
+  "identifier": "im:1f4406be-bb4d-5bdd-ab77-5f2fad7bfc9b",
+  "name": "Cumulative PP Set for Solving Equivalent Ratio Problems",
+  "alternateName": "6.2.14",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:69f54880-625b-5f01-8d97-21862a906521",
+    "courseCode": "6.2.14"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25558",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:17 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Solving Equivalent Ratio Problems</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244791.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244791.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "name": "Aligned PP Set for Part-Part-Whole Ratios",
     "courseCode": "6.2.15"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244791.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244791.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:86b8d387-bff2-5fde-bdad-478aa40516ad",
+  "identifier": "im:86b8d387-bff2-5fde-bdad-478aa40516ad",
+  "name": "Aligned PP Set for Part-Part-Whole Ratios",
+  "alternateName": "6.2.15",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "courseCode": "6.2.15"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25559",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:17 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Part-Part-Whole Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244802.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244802.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:af1dda56-8b53-5d71-a460-ec803c3bd936",
+  "identifier": "im:af1dda56-8b53-5d71-a460-ec803c3bd936",
+  "name": "Cumulative PP Set for Part-Part-Whole Ratios",
+  "alternateName": "6.2.15",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "courseCode": "6.2.15"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25560",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:18 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Part-Part-Whole Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244802.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244802.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:09fcc3ab-8818-5539-a1d7-437787f58228",
+    "name": "Cumulative PP Set for Part-Part-Whole Ratios",
     "courseCode": "6.2.15"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244814.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244814.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "name": "Aligned PP Set for Solving More Ratio Problems",
     "courseCode": "6.2.16"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244814.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244814.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:7b5ed137-763b-5075-89ec-ce376501eb9e",
+  "identifier": "im:7b5ed137-763b-5075-89ec-ce376501eb9e",
+  "name": "Aligned PP Set for Solving More Ratio Problems",
+  "alternateName": "6.2.16",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "courseCode": "6.2.16"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25561",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:18 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for Solving More Ratio Problems</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244825.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244825.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:b72390ea-37a5-5534-b9f9-ab34796af19d",
+  "identifier": "im:b72390ea-37a5-5534-b9f9-ab34796af19d",
+  "name": "Cumulative PP Set for Solving More Ratio Problems",
+  "alternateName": "6.2.16",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "courseCode": "6.2.16"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25562",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:18 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Cumulative PP Set for Solving More Ratio Problems</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/practice-problem-set-node-244825.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244825.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:9fa3e1d8-ed00-575f-9e36-95f55c616287",
+    "name": "Cumulative PP Set for Solving More Ratio Problems",
     "courseCode": "6.2.16"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244837.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244837.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Lesson",
     "@id": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+    "name": "Aligned PP Set for A Fermi Problem",
     "courseCode": "6.2.17"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Practice problem set"
   ],

--- a/build/cms_im-PR1142/practice-problem-set-node-244837.ocx.html
+++ b/build/cms_im-PR1142/practice-problem-set-node-244837.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:PracticeProblemSet",
+  "@id": "im:dc71a1da-8966-5e07-a598-5ac188f7ad9c",
+  "identifier": "im:dc71a1da-8966-5e07-a598-5ac188f7ad9c",
+  "name": "Aligned PP Set for A Fermi Problem",
+  "alternateName": "6.2.17",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Lesson",
+    "@id": "im:8201cc6d-2cdf-5faf-b43d-af7262a0ede6",
+    "courseCode": "6.2.17"
+  },
+  "learningResourceType": [
+    "Practice problem set"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:PracticeProblemSet",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/practice_problem_sets/25563",
+  "dateCreated": "2019-05-20 07:52:20 UTC",
+  "dateModified": "2020-05-04 20:27:25 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Assessment.name">Aligned PP Set for A Fermi Problem</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/section-node-244423.ocx.html
+++ b/build/cms_im-PR1142/section-node-244423.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Section",
+  "@id": "im:5a855ebc-4e35-52f2-bb33-4cc9e81e4174",
+  "identifier": "im:5a855ebc-4e35-52f2-bb33-4cc9e81e4174",
+  "name": "What are Ratios?",
+  "alternateName": "6.2.",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Section"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Section",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/sections/4208",
+  "dateCreated": "2019-05-20 07:42:54 UTC",
+  "dateModified": "2020-06-25 12:55:58 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Unit.name">What are Ratios?</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/section-node-244423.ocx.html
+++ b/build/cms_im-PR1142/section-node-244423.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "What are Ratios?",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Section"
   ],

--- a/build/cms_im-PR1142/section-node-244476.ocx.html
+++ b/build/cms_im-PR1142/section-node-244476.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Section",
+  "@id": "im:2ede255d-a6eb-5b61-a7b0-259eecd4ed0a",
+  "identifier": "im:2ede255d-a6eb-5b61-a7b0-259eecd4ed0a",
+  "name": "Equivalent Ratios",
+  "alternateName": "6.2.",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Section"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Section",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/sections/4224",
+  "dateCreated": "2019-05-20 07:42:56 UTC",
+  "dateModified": "2020-05-04 20:23:28 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Unit.name">Equivalent Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/section-node-244476.ocx.html
+++ b/build/cms_im-PR1142/section-node-244476.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "Equivalent Ratios",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Section"
   ],

--- a/build/cms_im-PR1142/section-node-244560.ocx.html
+++ b/build/cms_im-PR1142/section-node-244560.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "Representing Equivalent Ratios",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Section"
   ],

--- a/build/cms_im-PR1142/section-node-244560.ocx.html
+++ b/build/cms_im-PR1142/section-node-244560.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Section",
+  "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+  "identifier": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+  "name": "Representing Equivalent Ratios",
+  "alternateName": "6.2.",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Section"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Section",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/sections/4279",
+  "dateCreated": "2019-05-20 07:43:01 UTC",
+  "dateModified": "2020-06-25 12:55:37 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Unit.name">Representing Equivalent Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/section-node-244685.ocx.html
+++ b/build/cms_im-PR1142/section-node-244685.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Section",
+  "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+  "identifier": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+  "name": "Solving Ratio and Rate Problems",
+  "alternateName": "6.2.",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Section"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Section",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/sections/4305",
+  "dateCreated": "2019-05-20 07:43:09 UTC",
+  "dateModified": "2020-06-25 12:55:12 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Unit.name">Solving Ratio and Rate Problems</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/section-node-244685.ocx.html
+++ b/build/cms_im-PR1142/section-node-244685.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "Solving Ratio and Rate Problems",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Section"
   ],

--- a/build/cms_im-PR1142/section-node-244784.ocx.html
+++ b/build/cms_im-PR1142/section-node-244784.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Section",
+  "@id": "im:13b9e821-9a4c-5948-80fd-6b079ec22658",
+  "identifier": "im:13b9e821-9a4c-5948-80fd-6b079ec22658",
+  "name": "Part-part-whole Ratios",
+  "alternateName": "6.2.",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Section"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Section",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/sections/4226",
+  "dateCreated": "2019-05-20 07:42:56 UTC",
+  "dateModified": "2020-05-04 20:23:36 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Unit.name">Part-part-whole Ratios</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/section-node-244784.ocx.html
+++ b/build/cms_im-PR1142/section-node-244784.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "Part-part-whole Ratios",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Section"
   ],

--- a/build/cms_im-PR1142/section-node-244832.ocx.html
+++ b/build/cms_im-PR1142/section-node-244832.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Section",
+  "@id": "im:c2939826-ccbe-52dd-aea6-ed30ec624f85",
+  "identifier": "im:c2939826-ccbe-52dd-aea6-ed30ec624f85",
+  "name": "Let&#x2019;s Put it to Work",
+  "alternateName": "6.2.",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Unit",
+    "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "courseCode": "6.2"
+  },
+  "learningResourceType": [
+    "Section"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Section",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/sections/4227",
+  "dateCreated": "2019-05-20 07:42:56 UTC",
+  "dateModified": "2020-05-04 20:27:25 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Unit.name">Let&#x2019;s Put it to Work</div>
+  </body>
+</html>

--- a/build/cms_im-PR1142/section-node-244832.ocx.html
+++ b/build/cms_im-PR1142/section-node-244832.ocx.html
@@ -35,8 +35,12 @@
   "isPartOf": {
     "@type": "oer:Unit",
     "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+    "name": "Let&#x2019;s Put it to Work",
     "courseCode": "6.2"
   },
+  "hasPart": [
+
+  ],
   "learningResourceType": [
     "Section"
   ],

--- a/build/cms_im-PR1142/sitemap.xml
+++ b/build/cms_im-PR1142/sitemap.xml
@@ -1,0 +1,1108 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>unit-node-244422.ocx.html</loc>
+    <lastmod>2022-08-05 14:45:35 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Unit</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>section-node-244423.ocx.html</loc>
+    <lastmod>2020-06-25 12:55:58 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Section</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244424.ocx.html</loc>
+    <lastmod>2021-07-26 13:55:31 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244425.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:25 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244426.ocx.html</loc>
+    <lastmod>2021-07-26 13:54:18 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244427.ocx.html</loc>
+    <lastmod>2021-07-26 13:55:16 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244428.ocx.html</loc>
+    <lastmod>2020-08-18 15:01:16 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244429.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:11 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244446.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:26 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244453.ocx.html</loc>
+    <lastmod>2021-07-26 14:01:57 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244454.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:11 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244455.ocx.html</loc>
+    <lastmod>2021-07-26 14:00:25 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244456.ocx.html</loc>
+    <lastmod>2021-07-26 13:57:41 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244457.ocx.html</loc>
+    <lastmod>2021-07-26 13:59:48 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244458.ocx.html</loc>
+    <lastmod>2020-08-18 15:01:29 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244459.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:11 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244469.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:11 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>section-node-244476.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:28 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Section</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244477.ocx.html</loc>
+    <lastmod>2021-07-26 14:05:54 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244478.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:29 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244479.ocx.html</loc>
+    <lastmod>2021-07-26 14:04:25 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244480.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:29 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244481.ocx.html</loc>
+    <lastmod>2020-08-18 15:01:49 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244482.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:12 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244497.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:12 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244506.ocx.html</loc>
+    <lastmod>2021-07-26 14:08:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244507.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:27 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244508.ocx.html</loc>
+    <lastmod>2021-07-26 14:07:34 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244509.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:27 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244510.ocx.html</loc>
+    <lastmod>2020-08-18 15:02:04 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244511.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:12 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244526.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:27 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244534.ocx.html</loc>
+    <lastmod>2021-07-26 14:10:00 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244535.ocx.html</loc>
+    <lastmod>2020-06-23 20:52:00 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244536.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:35 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244537.ocx.html</loc>
+    <lastmod>2021-07-26 14:09:47 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244538.ocx.html</loc>
+    <lastmod>2020-10-01 14:05:47 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244539.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244553.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>section-node-244560.ocx.html</loc>
+    <lastmod>2020-06-25 12:55:37 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Section</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244561.ocx.html</loc>
+    <lastmod>2021-07-22 14:07:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244562.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244563.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244564.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244565.ocx.html</loc>
+    <lastmod>2020-08-18 15:03:31 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244566.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244575.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244582.ocx.html</loc>
+    <lastmod>2021-07-26 14:15:51 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244583.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:39 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244584.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:41 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244585.ocx.html</loc>
+    <lastmod>2021-07-26 15:19:55 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244586.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244587.ocx.html</loc>
+    <lastmod>2020-08-18 15:03:50 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244588.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:14 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244598.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:14 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244607.ocx.html</loc>
+    <lastmod>2021-07-22 14:08:13 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244608.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:44 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244609.ocx.html</loc>
+    <lastmod>2021-07-26 15:21:39 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244610.ocx.html</loc>
+    <lastmod>2021-07-26 15:22:24 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244611.ocx.html</loc>
+    <lastmod>2020-08-18 15:04:24 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244612.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:14 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244625.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:30 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244632.ocx.html</loc>
+    <lastmod>2021-07-26 15:28:04 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244633.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:14 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244634.ocx.html</loc>
+    <lastmod>2021-07-26 15:27:31 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244635.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:51 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244636.ocx.html</loc>
+    <lastmod>2020-08-18 15:04:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244637.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244651.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244660.ocx.html</loc>
+    <lastmod>2021-07-22 14:07:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244661.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244662.ocx.html</loc>
+    <lastmod>2020-06-25 11:39:32 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244663.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:50 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244664.ocx.html</loc>
+    <lastmod>2020-08-18 15:04:50 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244665.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244677.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>section-node-244685.ocx.html</loc>
+    <lastmod>2020-06-25 12:55:12 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Section</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244686.ocx.html</loc>
+    <lastmod>2021-07-22 14:07:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244687.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244688.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:52 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244689.ocx.html</loc>
+    <lastmod>2020-06-24 15:40:53 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244690.ocx.html</loc>
+    <lastmod>2020-08-18 15:05:08 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244691.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:16 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244702.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:16 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244709.ocx.html</loc>
+    <lastmod>2021-07-22 14:07:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244710.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:16 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244711.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:16 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244712.ocx.html</loc>
+    <lastmod>2020-06-25 11:39:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244713.ocx.html</loc>
+    <lastmod>2020-06-24 15:41:00 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244714.ocx.html</loc>
+    <lastmod>2020-08-18 15:05:20 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244715.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:16 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244732.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:17 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244740.ocx.html</loc>
+    <lastmod>2021-07-26 15:30:55 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244741.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:33 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244742.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:33 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244743.ocx.html</loc>
+    <lastmod>2021-07-26 15:30:41 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244744.ocx.html</loc>
+    <lastmod>2020-08-18 15:05:33 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244745.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:16 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244757.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:34 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244764.ocx.html</loc>
+    <lastmod>2021-07-26 15:32:57 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244765.ocx.html</loc>
+    <lastmod>2020-06-23 20:52:29 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244766.ocx.html</loc>
+    <lastmod>2021-07-26 15:32:16 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244767.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:17 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244768.ocx.html</loc>
+    <lastmod>2020-08-18 15:05:47 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244769.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:17 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244777.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:17 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>section-node-244784.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Section</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244785.ocx.html</loc>
+    <lastmod>2021-07-22 14:07:15 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244786.ocx.html</loc>
+    <lastmod>2020-06-23 20:52:31 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244787.ocx.html</loc>
+    <lastmod>2022-12-09 17:32:28 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244788.ocx.html</loc>
+    <lastmod>2021-07-26 15:35:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244789.ocx.html</loc>
+    <lastmod>2021-07-26 15:36:06 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244790.ocx.html</loc>
+    <lastmod>2020-08-18 15:06:07 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244791.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:17 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244802.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:18 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244809.ocx.html</loc>
+    <lastmod>2021-07-26 15:39:38 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244810.ocx.html</loc>
+    <lastmod>2020-06-24 15:41:10 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244811.ocx.html</loc>
+    <lastmod>2020-06-24 15:41:07 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244812.ocx.html</loc>
+    <lastmod>2021-07-26 15:39:05 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>cool-down-node-244813.ocx.html</loc>
+    <lastmod>2020-08-18 15:06:20 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/CoolDown</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244814.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:18 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244825.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:18 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>section-node-244832.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:25 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Section</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>lesson-node-244833.ocx.html</loc>
+    <lastmod>2021-07-26 15:41:35 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Lesson</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244834.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:25 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244835.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:25 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>activity-node-244836.ocx.html</loc>
+    <lastmod>2021-07-26 15:41:17 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Activity</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>practice-problem-set-node-244837.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:25 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/PracticeProblemSet</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-node-244839.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Assessment</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244840.ocx.html</loc>
+    <lastmod>2020-06-24 16:49:08 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244841.ocx.html</loc>
+    <lastmod>2020-06-24 16:49:08 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244842.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244843.ocx.html</loc>
+    <lastmod>2020-06-24 16:49:08 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244844.ocx.html</loc>
+    <lastmod>2020-06-24 16:49:09 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244845.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-node-266329.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Assessment</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266331.ocx.html</loc>
+    <lastmod>2020-06-24 16:36:49 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266332.ocx.html</loc>
+    <lastmod>2020-06-24 16:36:50 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266333.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266334.ocx.html</loc>
+    <lastmod>2020-06-24 16:36:52 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266335.ocx.html</loc>
+    <lastmod>2020-06-24 16:36:51 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266336.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:36 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-node-244846.ocx.html</loc>
+    <lastmod>2020-05-04 20:23:37 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Assessment</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244847.ocx.html</loc>
+    <lastmod>2020-06-24 16:49:11 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244848.ocx.html</loc>
+    <lastmod>2020-06-24 16:49:10 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244849.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:25 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244850.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:25 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244851.ocx.html</loc>
+    <lastmod>2020-06-25 11:57:56 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244852.ocx.html</loc>
+    <lastmod>2020-05-04 20:27:26 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-244853.ocx.html</loc>
+    <lastmod>2021-10-19 14:21:26 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-node-266337.ocx.html</loc>
+    <lastmod>2020-05-05 13:50:04 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/Assessment</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266338.ocx.html</loc>
+    <lastmod>2020-06-24 16:36:57 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266339.ocx.html</loc>
+    <lastmod>2020-06-24 16:36:59 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266340.ocx.html</loc>
+    <lastmod>2020-05-06 16:34:50 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266341.ocx.html</loc>
+    <lastmod>2020-05-06 16:34:51 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266342.ocx.html</loc>
+    <lastmod>2020-06-25 11:57:57 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266343.ocx.html</loc>
+    <lastmod>2020-05-06 16:34:52 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+  <url>
+    <loc>assessment-problem-node-266344.ocx.html</loc>
+    <lastmod>2021-10-19 14:22:55 UTC</lastmod>
+    <ocx:ocx>
+      <ocx:type>http://oerschema.org/AssessmentProblem</ocx:type>
+    </ocx:ocx>
+  </url>
+</urlset>

--- a/build/cms_im-PR1142/unit-node-244422.ocx.html
+++ b/build/cms_im-PR1142/unit-node-244422.ocx.html
@@ -35,8 +35,125 @@
   "isPartOf": {
     "@type": "oer:Course",
     "@id": "im:fb26c716-2b54-51b2-97eb-dc314fe1a6f8",
+    "name": "Introducing Ratios",
     "courseCode": "6"
   },
+  "hasPart": [
+    {
+      "@type": "oer:Assessment",
+      "@id": "im:fff5b1e0-659e-501c-9019-82849e3a1734",
+      "name": "Check Your Readiness (A)",
+      "alternateName": "6.2"
+    },
+    {
+      "@type": "oer:Assessment",
+      "@id": "im:6ce070f1-75ec-5fdc-be9f-290b122bb6e9",
+      "name": "Check Your Readiness (B)",
+      "alternateName": "6.2"
+    },
+    {
+      "@type": "oer:Section",
+      "@id": "im:5a855ebc-4e35-52f2-bb33-4cc9e81e4174",
+      "name": "What are Ratios?",
+      "alternateName": "6.2."
+    },
+    {
+      "@type": "oer:Section",
+      "@id": "im:2ede255d-a6eb-5b61-a7b0-259eecd4ed0a",
+      "name": "Equivalent Ratios",
+      "alternateName": "6.2."
+    },
+    {
+      "@type": "oer:Section",
+      "@id": "im:fe4f3c5f-7744-5cdb-87fa-9b0b2e67e953",
+      "name": "Representing Equivalent Ratios",
+      "alternateName": "6.2."
+    },
+    {
+      "@type": "oer:Section",
+      "@id": "im:382bcf64-5313-5906-89c2-f51056a66f29",
+      "name": "Solving Ratio and Rate Problems",
+      "alternateName": "6.2."
+    },
+    {
+      "@type": "oer:Section",
+      "@id": "im:13b9e821-9a4c-5948-80fd-6b079ec22658",
+      "name": "Part-part-whole Ratios",
+      "alternateName": "6.2."
+    },
+    {
+      "@type": "oer:Section",
+      "@id": "im:c2939826-ccbe-52dd-aea6-ed30ec624f85",
+      "name": "Let&#x2019;s Put it to Work",
+      "alternateName": "6.2."
+    },
+    {
+      "@type": "oer:Assessment",
+      "@id": "im:09cd61bc-33fa-5fd5-aa08-b6d06ac3618a",
+      "name": "End-of-Unit Assessment (A)",
+      "alternateName": "6.2"
+    },
+    {
+      "@type": "oer:Assessment",
+      "@id": "im:e58c4726-4a51-5d24-8f77-6a2b4bfb044c",
+      "name": "End-of-Unit Assessment (B)",
+      "alternateName": "6.2"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:2fd8a28c-2b1c-5e04-9d66-616569fad2d3",
+      "name": "double number line diagram",
+      "alternateName": "double number line diagram"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:965c508a-eebf-518b-a9db-a0113ef9902b",
+      "name": "equivalent ratios",
+      "alternateName": "equivalent ratios"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:761665ae-430c-5fa3-8f15-823386c237ea",
+      "name": "meters per second",
+      "alternateName": "meters per second"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:4e6e8e7d-48c8-5ce1-9db2-d2aa8aad19ec",
+      "name": "per",
+      "alternateName": "per"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:9ba81e89-68ec-5f7e-a5e5-f3c2a333c071",
+      "name": "ratio",
+      "alternateName": "ratio"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:bab8d7db-96f6-5a4a-a483-16571b0af8d2",
+      "name": "same rate",
+      "alternateName": "same rate"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:5d496d90-5729-5d78-a802-73ae5d62b363",
+      "name": "table",
+      "alternateName": "table"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:8a441eda-3496-5f62-9b27-a29f32d38db9",
+      "name": "tape diagram",
+      "alternateName": "tape diagram"
+    },
+    {
+      "@type": "oer:Tag",
+      "@id": "im:79cd2213-4259-5ec7-9c91-28714654c9f2",
+      "name": "unit price",
+      "alternateName": "unit price"
+    }
+  ],
   "learningResourceType": [
     "Unit"
   ],

--- a/build/cms_im-PR1142/unit-node-244422.ocx.html
+++ b/build/cms_im-PR1142/unit-node-244422.ocx.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "UTF-8" "">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <script type="application/ld+json">{
+  "@context": [
+    "https://schema.org/",
+    {
+      "oer": "https://oerschema.org/",
+      "ocx": "https://github.com/K12OCX/k12ocx-specs/",
+      "im": "https://ocx-specs.illustrativemathematics.org/"
+    }
+  ],
+  "@type": "oer:Unit",
+  "@id": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+  "identifier": "im:f888bbca-9ec6-5820-af9a-39bb4916e3d5",
+  "name": "Introducing Ratios",
+  "alternateName": "6.2",
+  "forCourse": {
+    "@type": "oer:Course",
+    "courseIdentifier": "Grade 6"
+  },
+  "author": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "provider": {
+    "@type": "http://schema.org/Organization",
+    "name": "Illustrative Mathematics",
+    "email": "email@illustrativemathematics.org",
+    "url": "https://illustrativemathematics.org/"
+  },
+  "isPartOf": {
+    "@type": "oer:Course",
+    "@id": "im:fb26c716-2b54-51b2-97eb-dc314fe1a6f8",
+    "courseCode": "6"
+  },
+  "learningResourceType": [
+    "Unit"
+  ],
+  "ocx:submissionType": "Text, Recording, File Upload, URL, Student Annotation",
+  "educationalUse": "im:Unit",
+  "gradingformat": "oer:CompletionGradeFormat",
+  "ocx:interactionType": "Text, Paper, Upload, Online document",
+  "ocx:submissionGroup": "Individual, Small Group, or Class",
+  "ocx:totalPoints": "0",
+  "ocx:accessToInformation": "",
+  "encoding": [
+    {
+      "encodingFormat": "application/msword",
+      "contentUrl": "***TODO*** what URL(s) should we use?"
+    }
+  ],
+  "timeRequired": "15",
+  "url": "https://cms-assets.illustrativemathematics.org/units/1072",
+  "dateCreated": "2019-05-20 07:42:48 UTC",
+  "dateModified": "2022-08-05 14:45:35 UTC",
+  "audience": {
+    "@type": "EducationalAudience",
+    "educationalRole": "student"
+  },
+  "inLanguage": "EN",
+  "cc:license": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "cc:morePermissions": "TBD",
+  "cc:attributionName": "Illustrative Mathematics",
+  "cc:attributionURL": "https://illustrativemathematics.org",
+  "cc:useGuidelines": "TBD"
+}</script>
+  </head>
+  <body>
+    <div class="Module.name">Introducing Ratios</div>
+  </body>
+</html>


### PR DESCRIPTION
this PR corresponds to [CMS PR 1142](https://github.com/illustrativemathematics/cms_im/pull/1142) 

* i have again reorganized the files 
* there is now a folder for the node being exported, `ed_node-244422-6.2`. this gives us the flexibility to look at static exports for other nodes going forward.
* for reference, the commits will continue to point to relevant PRs on the CMS side